### PR TITLE
fixes broken RTD build

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+API Reference
+*************
 
 .. If you created a package, create one automodule per module in the package.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,14 +23,8 @@ Table of Contents
 .. toctree::
     :caption: Tutorials
 
-.. todo:: Add any Learn guide links here. If there are none, then simply delete this todo and leave
-    the toctree above for use later.
-
 .. toctree::
     :caption: Related Products
-
-.. todo:: Add any product links here. If there are none, then simply delete this todo and leave
-    the toctree above for use later.
 
 .. toctree::
     :caption: Other Links


### PR DESCRIPTION
This fixes the errors with the RTD build by removing some todos and adding a placeholder title for the API page that seems to be necessary due to the state of the repo. Other drivers I've worked on didn't actually need the title in `api.rst` but I think that's because those projects actually had docstrings that generated something to show up on the API reference page. 