### PR TITLE
Add tail_length exception, update example imports.

### DIFF
--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -57,7 +57,12 @@ class Comet(Animation):
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
     :param int tail_length: The length of the comet. Defaults to 10. Cannot exceed the number of
                             pixels present in the pixel object, e.g. if the strip is 30 pixels
-                            long, the ``tail_length`` cannot exceed 30 pixels.
+                            long, the ``tail_length`` cannot exceed 30 pixels, or, in the case of a
+                            pixel mapped grid, if the width of the grid is 13 pixels, a horizontal
+                            comet tail cannot exceed 13 pixels. To find the lenth of the
+                            ``pixel_object``, include a ``print(len(PIXEL_OBJECT_NAME))`` in your
+                            code anywhere after the object creation, where ``PIXEL_OBJECT_NAME`` is
+                            the name assigned to the object, such as ``pixels``.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
     :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
     """
@@ -73,6 +78,10 @@ class Comet(Animation):
         bounce=False,
         name=None,
     ):
+        if tail_length > len(pixel_object):
+            raise ValueError(
+                "Tail length must be less than the length of the pixel_object."
+            )
         self._tail_length = tail_length + 1
         self._color_step = 0.9 / tail_length
         self._color_offset = 0.1

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -79,7 +79,7 @@ class Comet(Animation):
         name=None,
     ):
         if tail_length is None:
-            tail_length = int(len(pixel_object) / 4)
+            tail_length = len(pixel_object) // 4
         else:
             tail_length = max(2, min(tail_length, len(pixel_object)))
         self._tail_length = tail_length

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -73,16 +73,16 @@ class Comet(Animation):
         pixel_object,
         speed,
         color,
-        tail_length=10,
+        tail_length=None,
         reverse=False,
         bounce=False,
         name=None,
     ):
-        if tail_length > len(pixel_object):
-            raise ValueError(
-                "Tail length must be less than the length of the pixel_object."
-            )
-        self._tail_length = tail_length + 1
+        if tail_length is None:
+            tail_length = int(len(pixel_object) / 4)
+        else:
+            tail_length = max(2, min(tail_length, len(pixel_object)))
+        self._tail_length = tail_length
         self._color_step = 0.9 / tail_length
         self._color_offset = 0.1
         self._comet_colors = None

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -68,12 +68,12 @@ class Comet(Animation):
         pixel_object,
         speed,
         color,
-        tail_length=None,
+        tail_length=0,
         reverse=False,
         bounce=False,
         name=None,
     ):
-        if tail_length is None:
+        if tail_length is 0:
             tail_length = len(pixel_object) // 4
         else:
             tail_length = max(2, min(tail_length, len(pixel_object)))

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -55,14 +55,9 @@ class Comet(Animation):
     :param pixel_object: The initialised LED object.
     :param float speed: Animation speed in seconds, e.g. ``0.1``.
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
-    :param int tail_length: The length of the comet. Defaults to 10. Cannot exceed the number of
-                            pixels present in the pixel object, e.g. if the strip is 30 pixels
-                            long, the ``tail_length`` cannot exceed 30 pixels, or, in the case of a
-                            pixel mapped grid, if the width of the grid is 13 pixels, a horizontal
-                            comet tail cannot exceed 13 pixels. To find the lenth of the
-                            ``pixel_object``, include a ``print(len(PIXEL_OBJECT_NAME))`` in your
-                            code anywhere after the object creation, where ``PIXEL_OBJECT_NAME`` is
-                            the name assigned to the object, such as ``pixels``.
+    :param int tail_length: The length of the comet. Defaults to 25% of the length of the
+                            ``pixel_object``. Automatically compensates for a minimum of 2 and a
+                            maximum of the length of the ``pixel_object``.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
     :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
     """

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -73,7 +73,7 @@ class Comet(Animation):
         bounce=False,
         name=None,
     ):
-        if tail_length is 0:
+        if tail_length == 0:
             tail_length = len(pixel_object) // 4
         else:
             tail_length = max(2, min(tail_length, len(pixel_object)))

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -96,7 +96,7 @@ class AnimationSequence:
         self,
         *members,
         advance_interval=None,
-        auto_clear=False,
+        auto_clear=True,
         random_order=False,
         auto_reset=False,
         advance_on_cycle_complete=False,

--- a/examples/led_animation_all_animations.py
+++ b/examples/led_animation_all_animations.py
@@ -9,18 +9,18 @@ This example does not work on SAMD21 (M0) boards.
 import board
 import neopixel
 
-import adafruit_led_animation.animation.blink as blink_animation
-import adafruit_led_animation.animation.sparklepulse as sparklepulse_animation
-import adafruit_led_animation.animation.comet as comet_animation
-import adafruit_led_animation.animation.chase as chase_animation
-import adafruit_led_animation.animation.pulse as pulse_animation
-import adafruit_led_animation.animation.sparkle as sparkle_animation
-import adafruit_led_animation.animation.rainbowchase as rainbowchase_animation
-import adafruit_led_animation.animation.rainbowsparkle as rainbowsparkle_animation
-import adafruit_led_animation.animation.rainbowcomet as rainbowcomet_animation
-import adafruit_led_animation.animation.solid as solid_animation
-import adafruit_led_animation.animation.colorcycle as colorcycle_animation
-import adafruit_led_animation.animation.rainbow as rainbow_animation
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.animation.sparklepulse import SparklePulse
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.chase import Chase
+from adafruit_led_animation.animation.pulse import Pulse
+from adafruit_led_animation.animation.sparkle import Sparkle
+from adafruit_led_animation.animation.rainbowchase import RainbowChase
+from adafruit_led_animation.animation.rainbowsparkle import RainbowSparkle
+from adafruit_led_animation.animation.rainbowcomet import RainbowComet
+from adafruit_led_animation.animation.solid import Solid
+from adafruit_led_animation.animation.colorcycle import ColorCycle
+from adafruit_led_animation.animation.rainbow import Rainbow
 from adafruit_led_animation.sequence import AnimationSequence
 from adafruit_led_animation.color import PURPLE, WHITE, AMBER, JADE, MAGENTA, ORANGE
 
@@ -31,30 +31,18 @@ pixel_num = 32
 
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.2, auto_write=False)
 
-blink = blink_animation.Blink(pixels, speed=0.5, color=JADE)
-colorcycle = colorcycle_animation.ColorCycle(
-    pixels, speed=0.4, colors=[MAGENTA, ORANGE]
-)
-comet = comet_animation.Comet(
-    pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True
-)
-chase = chase_animation.Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
-pulse = pulse_animation.Pulse(pixels, speed=0.1, period=3, color=AMBER)
-sparkle = sparkle_animation.Sparkle(pixels, speed=0.1, color=PURPLE, num_sparkles=10)
-solid = solid_animation.Solid(pixels, color=JADE)
-rainbow = rainbow_animation.Rainbow(pixels, speed=0.1, period=2)
-sparkle_pulse = sparklepulse_animation.SparklePulse(
-    pixels, speed=0.1, period=3, color=JADE
-)
-rainbow_comet = rainbowcomet_animation.RainbowComet(
-    pixels, speed=0.1, tail_length=7, bounce=True
-)
-rainbow_chase = rainbowchase_animation.RainbowChase(
-    pixels, speed=0.1, size=3, spacing=2, wheel_step=8
-)
-rainbow_sparkle = rainbowsparkle_animation.RainbowSparkle(
-    pixels, speed=0.1, num_sparkles=15
-)
+blink = Blink(pixels, speed=0.5, color=JADE)
+colorcycle = ColorCycle(pixels, speed=0.4, colors=[MAGENTA, ORANGE])
+comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
+chase = Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
+pulse = Pulse(pixels, speed=0.1, period=3, color=AMBER)
+sparkle = Sparkle(pixels, speed=0.1, color=PURPLE, num_sparkles=10)
+solid = Solid(pixels, color=JADE)
+rainbow = Rainbow(pixels, speed=0.1, period=2)
+sparkle_pulse = SparklePulse(pixels, speed=0.1, period=3, color=JADE)
+rainbow_comet = RainbowComet(pixels, speed=0.1, tail_length=7, bounce=True)
+rainbow_chase = RainbowChase(pixels, speed=0.1, size=3, spacing=2, wheel_step=8)
+rainbow_sparkle = RainbowSparkle(pixels, speed=0.1, num_sparkles=15)
 
 
 animations = AnimationSequence(

--- a/examples/led_animation_gridmap.py
+++ b/examples/led_animation_gridmap.py
@@ -10,11 +10,11 @@ This example does not work on SAMD21 (M0) boards.
 import board
 import neopixel
 
-import adafruit_led_animation.animation.comet as comet_animation
-import adafruit_led_animation.animation.rainbowcomet as rainbowcomet_animation
-import adafruit_led_animation.animation.rainbowchase as rainbowchase_animation
-import adafruit_led_animation.animation.chase as chase_animation
-import adafruit_led_animation.animation.rainbow as rainbow_animation
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.rainbowcomet import RainbowComet
+from adafruit_led_animation.animation.rainbowchase import RainbowChase
+from adafruit_led_animation.animation.chase import Chase
+from adafruit_led_animation.animation.rainbow import Rainbow
 from adafruit_led_animation.sequence import AnimationSequence
 from adafruit_led_animation import helper
 from adafruit_led_animation.color import PURPLE, JADE, AMBER
@@ -29,25 +29,19 @@ pixel_wing_horizontal = helper.PixelMap.horizontal_lines(
     pixels, 8, 4, helper.horizontal_strip_gridmap(8, alternating=False)
 )
 
-comet_h = comet_animation.Comet(
+comet_h = Comet(
     pixel_wing_horizontal, speed=0.1, color=PURPLE, tail_length=3, bounce=True
 )
-comet_v = comet_animation.Comet(
-    pixel_wing_vertical, speed=0.1, color=AMBER, tail_length=6, bounce=True
-)
-chase_h = chase_animation.Chase(
-    pixel_wing_horizontal, speed=0.1, size=3, spacing=6, color=JADE
-)
-rainbow_chase_v = rainbowchase_animation.RainbowChase(
+comet_v = Comet(pixel_wing_vertical, speed=0.1, color=AMBER, tail_length=6, bounce=True)
+chase_h = Chase(pixel_wing_horizontal, speed=0.1, size=3, spacing=6, color=JADE)
+rainbow_chase_v = RainbowChase(
     pixel_wing_vertical, speed=0.1, size=3, spacing=2, wheel_step=8
 )
-rainbow_comet_v = rainbowcomet_animation.RainbowComet(
+rainbow_comet_v = RainbowComet(
     pixel_wing_vertical, speed=0.1, tail_length=7, bounce=True
 )
-rainbow_v = rainbow_animation.Rainbow(pixel_wing_vertical, speed=0.1, period=2)
-rainbow_chase_h = rainbowchase_animation.RainbowChase(
-    pixel_wing_horizontal, speed=0.1, size=3, spacing=3
-)
+rainbow_v = Rainbow(pixel_wing_vertical, speed=0.1, period=2)
+rainbow_chase_h = RainbowChase(pixel_wing_horizontal, speed=0.1, size=3, spacing=3)
 
 animations = AnimationSequence(
     rainbow_v,

--- a/examples/led_animation_sequence.py
+++ b/examples/led_animation_sequence.py
@@ -1,0 +1,38 @@
+"""
+This example uses AnimationsSequence to display multiple animations in sequence, at a five second
+interval.
+
+For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
+a different form of NeoPixels.
+
+This example does not work on SAMD21 (M0) boards.
+"""
+import board
+import neopixel
+
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.chase import Chase
+from adafruit_led_animation.animation.pulse import Pulse
+from adafruit_led_animation.sequence import AnimationSequence
+from adafruit_led_animation.color import PURPLE, WHITE, AMBER, JADE
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D6
+# Update to match the number of NeoPixels you have connected
+pixel_num = 32
+
+pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.2, auto_write=False)
+
+blink = Blink(pixels, speed=0.5, color=JADE)
+comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
+chase = Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
+pulse = Pulse(pixels, speed=0.1, period=3, color=AMBER)
+
+
+animations = AnimationSequence(
+    comet, blink, chase, pulse, advance_interval=5, auto_clear=True,
+)
+
+while True:
+    animations.animate()

--- a/examples/led_animation_simpletest.py
+++ b/examples/led_animation_simpletest.py
@@ -9,8 +9,8 @@ This example does not work on SAMD21 (M0) boards.
 """
 import board
 import neopixel
-import adafruit_led_animation.animation.comet as comet_animation
-import adafruit_led_animation.animation.chase as chase_animation
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.chase import Chase
 from adafruit_led_animation.sequence import AnimationSequence
 from adafruit_led_animation.color import PURPLE, WHITE
 
@@ -21,10 +21,8 @@ pixel_num = 32
 
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.2, auto_write=False)
 
-comet = comet_animation.Comet(
-    pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True
-)
-chase = chase_animation.Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
+comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
+chase = Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
 
 animations = AnimationSequence(comet, chase, advance_interval=5)
 

--- a/examples/led_animation_simpletest.py
+++ b/examples/led_animation_simpletest.py
@@ -1,18 +1,13 @@
 """
-This simpletest example repeatedly displays two animations, Comet and Chase, at a five second
-interval.
+This simpletest example displays the Blink animation.
 
 For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
 a different form of NeoPixels.
-
-This example does not work on SAMD21 (M0) boards.
 """
 import board
 import neopixel
-from adafruit_led_animation.animation.comet import Comet
-from adafruit_led_animation.animation.chase import Chase
-from adafruit_led_animation.sequence import AnimationSequence
-from adafruit_led_animation.color import PURPLE, WHITE
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.color import RED
 
 # Update to match the pin connected to your NeoPixels
 pixel_pin = board.D6
@@ -21,10 +16,7 @@ pixel_num = 32
 
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.2, auto_write=False)
 
-comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
-chase = Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
-
-animations = AnimationSequence(comet, chase, advance_interval=5)
+blink = Blink(pixels, speed=0.5, color=RED)
 
 while True:
-    animations.animate()
+    blink.animate()


### PR DESCRIPTION
Added exception for `tail_length` on Comet animation - if it was too long before, it failed with a slicing error on the line containing `animations.animate()` which was incredibly cryptic.

No idea why I thought I needed to make the example imports and usage more verbose. Thanks @dhalbert for noticing this.