### PR TITLE
Add OneShot sequence subclass to make it easy to run a sequence once

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -99,15 +99,16 @@ class Animation:
         for anim in self._peers:
             anim.draw()
             anim.after_draw()
+            anim.draw_count += 1
 
         for anim in self._peers:
             anim.show()
 
         # Note that the main animation cycle_complete flag is used, not the peer flag.
         for anim in self._peers:
-            if self.cycle_complete:
-                anim.on_cycle_complete()
+            if anim.cycle_complete:
                 anim.cycle_complete = False
+                anim.on_cycle_complete()
 
         self._next_update = now + self._speed_ns
         return True

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -119,12 +119,14 @@ class Comet(Animation):
             if self.bounce:
                 self.reverse = not self.reverse
                 self._direction = -self._direction
-            if self.reverse == self._initial_reverse:
+            else:
+                self.reset()
+            if self.reverse == self._initial_reverse and self.draw_count > 0:
                 self.cycle_complete = True
 
     def reset(self):
         """
-        Resets to the first color.
+        Resets to the first state.
         """
         self.reverse = self._initial_reverse
         if self.reverse:

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -382,7 +382,7 @@ def pulse_generator(period: float, animation_object, white=False, dotstar_pwm=Fa
         last_update = now
         pos = cycle_position = (cycle_position + time_since_last_draw) % period
         if pos < last_pos:
-            animation_object.on_cycle_complete()
+            animation_object.cycle_complete = True
         last_pos = pos
         if pos > half_period:
             pos = period - pos

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -279,8 +279,8 @@ class AnimationSequence:
 class AnimateOnce(AnimationSequence):
     """
     Wrapper around AnimationSequence that returns False to animate() until a sequence has completed.
-    Takes the same arguments as AnimationSequence, but overrides
-    advance_on_cycle_complete=True and advance_interval=0
+    Takes the same arguments as AnimationSequence, but overrides advance_on_cycle_complete=True
+    and advance_interval=0
 
     Example:
 

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -276,7 +276,7 @@ class AnimationSequence:
         self.current_animation.show()
 
 
-class OneShot(AnimationSequence):
+class AnimateOnce(AnimationSequence):
     """
     Wrapper around AnimationSequence that returns False to animate() until a sequence has completed.
     Takes the same arguments as AnimationSequence, but overrides
@@ -293,14 +293,14 @@ class OneShot(AnimationSequence):
         from adafruit_led_animation.animation.comet import Comet
         from adafruit_led_animation.animation.pulse import Pulse
         from adafruit_led_animation.color import BLUE, RED
-        from adafruit_led_animation.sequence import OneShot
+        from adafruit_led_animation.sequence import AnimateOnce
 
         strip_pixels = neopixel.NeoPixel(board.A1, 30, brightness=0.5, auto_write=False)
 
         comet = Comet(strip_pixels, 0.01, color=BLUE, bounce=False)
         pulse = Pulse(strip_pixels, 0.01, color=RED, period=2)
 
-        animations = OneShot(comet, pulse)
+        animations = AnimateOnce(comet, pulse)
 
         while animations.animate():
             pass


### PR DESCRIPTION
Add OneShot sequence subclass to make it easy to run a sequence once.
Also fixes some bugs in the animation sequence completion tracking.