### PR TITLE
Various bugfixes and simplifications

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -81,11 +81,13 @@ class Animation:
     def __str__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.name)
 
-    def animate(self):
+    def animate(self, show=True):
         """
         Call animate() from your code's main loop.  It will draw the animation draw() at intervals
         configured by the speed property (set from init).
 
+        :param bool show: Whether to automatically call show on the pixel object when an animation
+                          fires.  Default True.
         :return: True if the animation draw cycle was triggered, otherwise False.
         """
         if self._paused:
@@ -97,11 +99,13 @@ class Animation:
 
         # Draw related animations together
         for anim in self._peers:
+            anim.draw_count += 1
             anim.draw()
             anim.after_draw()
 
-        for anim in self._peers:
-            anim.show()
+        if show:
+            for anim in self._peers:
+                anim.show()
 
         # Note that the main animation cycle_complete flag is used, not the peer flag.
         for anim in self._peers:

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -148,7 +148,7 @@ class AnimationGroup:
         """
         self._also_notify.append(callback)
 
-    def animate(self):
+    def animate(self, show=True):
         """
         Call animate() from your code's main loop.  It will draw all of the animations
         in the group.
@@ -156,9 +156,12 @@ class AnimationGroup:
         :return: True if any animation draw cycle was triggered, otherwise False.
         """
         if self._sync:
-            return self._members[0].animate()
+            result = self._members[0].animate(show=False)
+            if result and show:
+                self._members[0].show()
+            return result
 
-        return any([item.animate() for item in self._members])
+        return any([item.animate(show) for item in self._members])
 
     @property
     def color(self):

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -124,7 +124,7 @@ class PixelMap:
         else:
             self._set_pixels(index, val)
 
-        if not self._pixels.auto_write:
+        if self.auto_write:
             self.show()
 
     def __getitem__(self, index):
@@ -310,7 +310,7 @@ class PixelSubset:
         else:
             self._pixels[index + self._start] = val
 
-        if not self._pixels.auto_write:
+        if self.auto_write:
             self.show()
 
     def __getitem__(self, index):

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -205,7 +205,7 @@ class AnimationSequence:
         """
         self.activate(random.randint(0, len(self._members) - 1))
 
-    def animate(self):
+    def animate(self, show=True):
         """
         Call animate() from your code's main loop.  It will draw the current animation
         or go to the next animation based on the advance_interval if set.
@@ -214,7 +214,7 @@ class AnimationSequence:
         """
         if not self._paused and self._advance_interval:
             self._auto_advance()
-        return self.current_animation.animate()
+        return self.current_animation.animate(show)
 
     @property
     def current_animation(self):


### PR DESCRIPTION
Adds a flag to disable calling show automatically, which can be used to avoid flickering when animations overlap.
Fix a bug in AnimationGroup where it incorrectly used the auto_write flag.
