### PR TITLE
Blink color fix

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -185,6 +185,8 @@ class Animation:
     def color(self, color):
         if self._color == color:
             return
+        if isinstance(color, int):
+            color = (color >> 16 & 0xFF, color >> 8 & 0xFF, color & 0xFF)
         self._set_color(color)
 
     def _set_color(self, color):
@@ -192,8 +194,6 @@ class Animation:
         Called after the color is changed, which includes at initialization.
         Override as needed.
         """
-        if isinstance(color, int):
-            color = (color >> 16 & 0xFF, color >> 8 & 0xFF, color & 0xFF)
         self._color = color
 
     @property

--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -68,7 +68,7 @@ class Animation:
         self._time_left_at_pause = 0
         self._also_notify = []
         self.speed = speed  # sets _speed_ns
-        self.color = color  # Triggers _recompute_color
+        self.color = color  # Triggers _set_color
         self.name = name
         self.cycle_complete = False
         self.notify_cycles = 1
@@ -185,10 +185,16 @@ class Animation:
     def color(self, color):
         if self._color == color:
             return
+        self._set_color(color)
+
+    def _set_color(self, color):
+        """
+        Called after the color is changed, which includes at initialization.
+        Override as needed.
+        """
         if isinstance(color, int):
             color = (color >> 16 & 0xFF, color >> 8 & 0xFF, color & 0xFF)
         self._color = color
-        self._recompute_color(color)
 
     @property
     def speed(self):
@@ -200,12 +206,6 @@ class Animation:
     @speed.setter
     def speed(self, seconds):
         self._speed_ns = int(seconds * NANOS_PER_SECOND)
-
-    def _recompute_color(self, color):
-        """
-        Called if the color is changed, which includes at initialization.
-        Override as needed.
-        """
 
     def on_cycle_complete(self):
         """

--- a/adafruit_led_animation/animation/blink.py
+++ b/adafruit_led_animation/animation/blink.py
@@ -60,5 +60,5 @@ class Blink(ColorCycle):
     def __init__(self, pixel_object, speed, color, name=None):
         super().__init__(pixel_object, speed, [color, BLACK], name=name)
 
-    def _recompute_color(self, color):
+    def _set_color(self, color):
         self.colors = [color, BLACK]

--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -92,10 +92,7 @@ class Comet(Animation):
 
     on_cycle_complete_supported = True
 
-    def _recompute_color(self, color):
-        self._comet_recompute_color(color)
-
-    def _comet_recompute_color(self, color):
+    def _set_color(self, color):
         self._comet_colors = [BLACK]
         for n in range(self._tail_length):
             self._comet_colors.append(

--- a/adafruit_led_animation/animation/rainbowcomet.py
+++ b/adafruit_led_animation/animation/rainbowcomet.py
@@ -82,7 +82,7 @@ class RainbowComet(Comet):
         self._colorwheel_offset = colorwheel_offset
         super().__init__(pixel_object, speed, 0, tail_length, reverse, bounce, name)
 
-    def _comet_recompute_color(self, color):
+    def _set_color(self, color):
         self._comet_colors = [BLACK]
         for n in range(self._tail_length):
             invert = self._tail_length - n - 1

--- a/adafruit_led_animation/animation/solid.py
+++ b/adafruit_led_animation/animation/solid.py
@@ -58,5 +58,5 @@ class Solid(ColorCycle):
     def __init__(self, pixel_object, color, name=None):
         super().__init__(pixel_object, speed=1, colors=[color], name=name)
 
-    def _recompute_color(self, color):
+    def _set_color(self, color):
         self.colors = [color]

--- a/adafruit_led_animation/animation/sparkle.py
+++ b/adafruit_led_animation/animation/sparkle.py
@@ -71,7 +71,7 @@ class Sparkle(Animation):
         self._pixels = []
         super().__init__(pixel_object, speed, color, name=name)
 
-    def _recompute_color(self, color):
+    def _set_color(self, color):
         half_color = tuple(color[rgb] // 4 for rgb in range(len(color)))
         dim_color = tuple(color[rgb] // 10 for rgb in range(len(color)))
         for pixel in range(len(self.pixel_object)):

--- a/adafruit_led_animation/animation/sparklepulse.py
+++ b/adafruit_led_animation/animation/sparklepulse.py
@@ -80,6 +80,9 @@ class SparklePulse(Sparkle):
         )
         self._generator = pulse_generator(self._period, self, dotstar_pwm=dotstar)
 
+    def _set_color(self, color):
+        self._color = color
+
     def draw(self):
         self._sparkle_color = next(self._generator)
         super().draw()


### PR DESCRIPTION
Fixes a bug where setting `.color` causes the blink animation to fail.  As part of the fix, a small code size for some animations was made, by refactoring the `color` setter to call `_set_color()`, which replaces `_recompute_color()`