### PR TITLE
make animation.fill() show the pixels

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -173,6 +173,7 @@ class Animation:
         Fills the pixel object with a color.
         """
         self.pixel_object.fill(color)
+        self.pixel_object.show()
 
     @property
     def color(self):

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -172,7 +172,6 @@ class AnimationSequence:
             self.current_animation.reset()
         if self.auto_clear:
             self.current_animation.fill(self.clear_color)
-            self.current_animation.show()
         if self._random:
             self.random()
         else:


### PR DESCRIPTION
This makes the API behaviour the same as it was before some recent refactors.