### PR TITLE
cycle_complete not triggered for Chase animation

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -102,7 +102,6 @@ class Animation:
             anim.draw_count += 1
             anim.draw()
             anim.after_draw()
-            anim.draw_count += 1
 
         if show:
             for anim in self._peers:


### PR DESCRIPTION
anim.draw_count was incremented twice in animation/__init__.py.  This caused the check for cycle_complete to not be triggered in chase.py as it was not expecting a double value .  See issue #56 