### PR TITLE
Use adafruit_ticks

### DIFF
--- a/adafruit_led_animation/__init__.py
+++ b/adafruit_led_animation/__init__.py
@@ -7,36 +7,3 @@ Timing for Adafruit LED Animation library.
 
 Author(s): Kattni Rembor
 """
-
-try:
-    from micropython import const
-except ImportError:
-
-    def const(value):  # pylint: disable=missing-docstring
-        return value
-
-
-try:
-    from time import monotonic_ns
-
-    monotonic_ns()  # Test monotonic_ns in 6.x
-
-    def monotonic_ms():
-        """
-        Return monotonic time in milliseconds.
-        """
-        return monotonic_ns() // NANOS_PER_MS
-
-
-except (ImportError, NotImplementedError):
-    import time
-
-    def monotonic_ms():
-        """
-        Implementation of monotonic_ms for platforms without time.monotonic_ns
-        """
-        return int(time.monotonic() * MS_PER_SECOND)
-
-
-NANOS_PER_MS = const(1000000)
-MS_PER_SECOND = const(1000)

--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -28,7 +28,10 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation.git"
 
-from adafruit_led_animation import MS_PER_SECOND, monotonic_ms
+from adafruit_ticks import ticks_ms, ticks_diff, ticks_add, ticks_less
+from micropython import const
+
+MS_PER_SECOND = const(1000)
 
 
 class Animation:
@@ -46,7 +49,7 @@ class Animation:
         self._speed_ms = 0
         self._color = None
         self._paused = paused
-        self._next_update = monotonic_ms()
+        self._next_update = ticks_ms()
         self._time_left_at_pause = 0
         self._also_notify = []
         self.speed = speed  # sets _speed_ms
@@ -75,8 +78,8 @@ class Animation:
         if self._paused:
             return False
 
-        now = monotonic_ms()
-        if now < self._next_update:
+        now = ticks_ms()
+        if ticks_less(now, self._next_update):
             return False
 
         # Draw related animations together
@@ -139,13 +142,13 @@ class Animation:
         Stops the animation until resumed.
         """
         self._paused = True
-        self._time_left_at_pause = max(0, monotonic_ms() - self._next_update)
+        self._time_left_at_pause = max(0, ticks_diff(ticks_ms(), self._next_update))
 
     def resume(self):
         """
         Resumes the animation.
         """
-        self._next_update = monotonic_ms() + self._time_left_at_pause
+        self._next_update = ticks_add(ticks_ms(), self._time_left_at_pause)
         self._time_left_at_pause = 0
         self._paused = False
 

--- a/adafruit_led_animation/animation/rainbow.py
+++ b/adafruit_led_animation/animation/rainbow.py
@@ -26,8 +26,8 @@ Implementation Notes
 """
 
 from adafruit_ticks import ticks_diff, ticks_ms
-from .animation import Animation
-from .color import BLACK, colorwheel
+from ..animation import Animation
+from ..color import BLACK, colorwheel
 from . import MS_PER_SECOND
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_led_animation/animation/rainbow.py
+++ b/adafruit_led_animation/animation/rainbow.py
@@ -25,9 +25,10 @@ Implementation Notes
 
 """
 
-from adafruit_led_animation.animation import Animation
-from adafruit_led_animation.color import BLACK, colorwheel
-from adafruit_led_animation import MS_PER_SECOND, monotonic_ms
+from adafruit_ticks import ticks_diff, ticks_ms
+from .animation import Animation
+from .color import BLACK, colorwheel
+from . import MS_PER_SECOND
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation.git"
@@ -73,13 +74,13 @@ class Rainbow(Animation):
         period = int(self._period * MS_PER_SECOND)
 
         num_pixels = len(self.pixel_object)
-        last_update = monotonic_ms()
+        last_update = ticks_ms()
         cycle_position = 0
         last_pos = 0
         while True:
             cycle_completed = False
-            now = monotonic_ms()
-            time_since_last_draw = now - last_update
+            now = ticks_ms()
+            time_since_last_draw = ticks_diff(now, last_update)
             last_update = now
             pos = cycle_position = (cycle_position + time_since_last_draw) % period
             if pos < last_pos:
@@ -116,6 +117,9 @@ class Rainbow(Animation):
                 ]
 
     def draw(self):
+        """
+        Draws the animation.
+        """
         next(self._generator)
 
     def reset(self):

--- a/adafruit_led_animation/animation/rainbowsparkle.py
+++ b/adafruit_led_animation/animation/rainbowsparkle.py
@@ -90,6 +90,7 @@ class RainbowSparkle(Rainbow):
                 )
 
     def after_draw(self):
+        """Steps run after the main draw()"""
         self.show()
         pixels = [
             random.randint(0, len(self.pixel_object) - 1)

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -27,8 +27,11 @@ Implementation Notes
 
 import math
 
-from . import MS_PER_SECOND, monotonic_ms
+from micropython import const
+from adafruit_ticks import ticks_diff, ticks_ms
 from .color import calculate_intensity
+
+MS_PER_SECOND = const(1000)
 
 
 class PixelMap:
@@ -325,12 +328,12 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
     period = int(period * MS_PER_SECOND)
     half_period = period // 2
 
-    last_update = monotonic_ms()
+    last_update = ticks_ms()
     cycle_position = 0
     last_pos = 0
     while True:
-        now = monotonic_ms()
-        time_since_last_draw = now - last_update
+        now = ticks_ms()
+        time_since_last_draw = ticks_diff(now, last_update)
         last_update = now
         pos = cycle_position = (cycle_position + time_since_last_draw) % period
         if pos < last_pos:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+Adafruit-CircuitPython-Ticks

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka",
+        "Adafruit-CircuitPython-Ticks",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
This cures problems where long-running animations would start to stutter on boards without `monotonic_ns` support (requires 7.x), while retaining full compatibility for 6.x.

~~I still need to test this on HW, which is why it's entered as a draft.~~ Tested all animations on Feather S2 & NeoKey 5x6 Ortho Snap-Apart

As for RAM/CIRCUITPY usage,
 * the adafruit_ticks mpy is 556 bytes (7.x)
 * the net decrease in mpy size of led animation library is a mere 21 bytes across all files
 * comparing the best (highest gc.mem_free()) of 5 runs before and after, 752 bytes more RAM are used after importing all animations

so, some additional RAM and disk space will be required by this change.  I don't think we freeze animations in anywhere so this doesn't affect flash firmware size.