### PR TITLE
Add push button examples for pausing, resuming, and cycling animations

### DIFF
--- a/examples/led_animation_cycle_animations.py
+++ b/examples/led_animation_cycle_animations.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2021 Alec Delaney
+# SPDX-License-Identifier: MIT
+
+"""
+This example uses AnimationsSequence along with a connected push button to cycle through
+two animations
+
+For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
+a different form of NeoPixels.
+"""
+import board
+import time
+import neopixel
+from digitalio import DigitalInOut, Direction, Pull
+
+from adafruit_led_animation.animation.solid import Solid
+from adafruit_led_animation.sequence import AnimationSequence
+from adafruit_led_animation.color import RED, BLUE
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D6
+# Update to match the number of NeoPixels you have connected
+pixel_num = 32
+
+# Update to matchpin connected to button that connect logic high when pushed
+button_pin = board.D3
+
+pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
+button = DigitalInOut(button_pin)
+button.direction = Direction.INPUT
+button.pull = Pull.DOWN
+
+solid_blue = Solid(pixels, color=BLUE)
+solid_red = Solid(pixels, color=RED)
+animation_sequence = AnimationSequence(solid_blue, solid_red, auto_clear=True)
+
+while True:
+    animation_sequence.animate()
+
+    # Pressing the button pauses the animation permanently
+    if button.value:
+        animation_sequence.next()
+        while button.value:
+            time.sleep(0.1) # Used for button debouncing
+    

--- a/examples/led_animation_cycle_animations.py
+++ b/examples/led_animation_cycle_animations.py
@@ -8,8 +8,8 @@ two animations
 For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
 a different form of NeoPixels.
 """
-import board
 import time
+import board
 import neopixel
 from digitalio import DigitalInOut, Direction, Pull
 

--- a/examples/led_animation_cycle_animations.py
+++ b/examples/led_animation_cycle_animations.py
@@ -41,5 +41,4 @@ while True:
     if button.value:
         animation_sequence.next()
         while button.value:
-            time.sleep(0.1) # Used for button debouncing
-    
+            time.sleep(0.1)  # Used for button debouncing

--- a/examples/led_animation_cycle_animations.py
+++ b/examples/led_animation_cycle_animations.py
@@ -28,7 +28,7 @@ button_pin = board.D3
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
 button = DigitalInOut(button_pin)
 button.direction = Direction.INPUT
-button.pull = Pull.DOWN
+button.pull = Pull.UP
 
 solid_blue = Solid(pixels, color=BLUE)
 solid_red = Solid(pixels, color=RED)
@@ -38,7 +38,7 @@ while True:
     animation_sequence.animate()
 
     # Pressing the button pauses the animation permanently
-    if button.value:
+    if not button.value:
         animation_sequence.next()
         while button.value:
             time.sleep(0.1)  # Used for button debouncing

--- a/examples/led_animation_freeze_animation.py
+++ b/examples/led_animation_freeze_animation.py
@@ -26,7 +26,7 @@ button_pin = board.D3
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
 button = DigitalInOut(button_pin)
 button.direction = Direction.INPUT
-button.pull = Pull.DOWN
+button.pull = Pull.UP
 
 pulse_animation = Pulse(pixels, speed=0.1, period=1, color=RED)
 
@@ -34,5 +34,5 @@ while True:
     pulse_animation.animate()
 
     # Pressing the button pauses the animation permanently
-    if button.value:
+    if not button.value:
         pulse_animation.freeze()

--- a/examples/led_animation_freeze_animation.py
+++ b/examples/led_animation_freeze_animation.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2021 Alec Delaney
+# SPDX-License-Identifier: MIT
+
+"""
+This example uses Pulse animation along with a connected push button to freeze
+the animation permanently when pressed
+
+For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
+a different form of NeoPixels.
+"""
+import board
+import neopixel
+from digitalio import DigitalInOut, Direction, Pull
+
+from adafruit_led_animation.animation.pulse import Pulse
+from adafruit_led_animation.color import RED
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D6
+# Update to match the number of NeoPixels you have connected
+pixel_num = 32
+
+# Update to matchpin connected to button that connect logic high when pushed
+button_pin = board.D3
+
+pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
+button = DigitalInOut(button_pin)
+button.direction = Direction.INPUT
+button.pull = Pull.DOWN
+
+pulse_animation = Pulse(pixels, speed=0.1, period=1, color=RED)
+
+while True:
+    pulse_animation.animate()
+
+    # Pressing the button pauses the animation permanently
+    if button.value:
+        pulse_animation.freeze()

--- a/examples/led_animation_resume_animation.py
+++ b/examples/led_animation_resume_animation.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2021 Alec Delaney
+# SPDX-License-Identifier: MIT
+
+"""
+This example uses Pulse animation along with a connected push button to start
+the animation when pressed
+
+For NeoPixel FeatherWing. Update pixel_pin and pixel_num to match your wiring if using
+a different form of NeoPixels.
+"""
+import board
+import neopixel
+from digitalio import DigitalInOut, Direction, Pull
+
+from adafruit_led_animation.animation.pulse import Pulse
+from adafruit_led_animation.color import RED
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D6
+# Update to match the number of NeoPixels you have connected
+pixel_num = 32
+
+# Update to matchpin connected to button that connect logic high when pushed
+button_pin = board.D3
+
+pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
+button = DigitalInOut(button_pin)
+button.direction = Direction.INPUT
+button.pull = Pull.DOWN
+
+# Create the animation and freeze it afterwards
+pulse_animation = Pulse(pixels, speed=0.1, period=1, color=RED)
+pulse_animation.freeze() 
+
+while True:
+    pulse_animation.animate()
+
+    # Pressing the button resumes (or in this case starts) the animation permanently
+    if button.value:
+        pulse_animation.resume()

--- a/examples/led_animation_resume_animation.py
+++ b/examples/led_animation_resume_animation.py
@@ -26,7 +26,7 @@ button_pin = board.D3
 pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
 button = DigitalInOut(button_pin)
 button.direction = Direction.INPUT
-button.pull = Pull.DOWN
+button.pull = Pull.UP
 
 # Create the animation and freeze it afterwards
 pulse_animation = Pulse(pixels, speed=0.1, period=1, color=RED)
@@ -36,5 +36,5 @@ while True:
     pulse_animation.animate()
 
     # Pressing the button resumes (or in this case starts) the animation permanently
-    if button.value:
+    if not button.value:
         pulse_animation.resume()

--- a/examples/led_animation_resume_animation.py
+++ b/examples/led_animation_resume_animation.py
@@ -30,7 +30,7 @@ button.pull = Pull.DOWN
 
 # Create the animation and freeze it afterwards
 pulse_animation = Pulse(pixels, speed=0.1, period=1, color=RED)
-pulse_animation.freeze() 
+pulse_animation.freeze()
 
 while True:
     pulse_animation.animate()


### PR DESCRIPTION
Resolves #77 by adding examples for for pausing, resuming, and cycling animations through a connected push button.  Tested code on `Adafruit CircuitPython 7.1.1 on 2022-01-14; Adafruit CircuitPlayground Express with samd21g18` (with only the expected changes to board pin references and neopixel count).  Working as expected!