### PR TITLE
Animations using after_draw() don't work properly

### DIFF
--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -83,7 +83,6 @@ class Animation:
         for anim in self._peers:
             anim.draw_count += 1
             anim.draw()
-            anim.after_draw()
 
         if show:
             for anim in self._peers:

--- a/adafruit_led_animation/animation/rainbowsparkle.py
+++ b/adafruit_led_animation/animation/rainbowsparkle.py
@@ -89,8 +89,8 @@ class RainbowSparkle(Rainbow):
                     int(self._background_brightness * color[2]),
                 )
 
-    def after_draw(self):
-        self.show()
+    def draw(self):
+        super().draw()
         pixels = [
             random.randint(0, len(self.pixel_object) - 1)
             for n in range(self._num_sparkles)

--- a/adafruit_led_animation/animation/sparkle.py
+++ b/adafruit_led_animation/animation/sparkle.py
@@ -83,13 +83,10 @@ class Sparkle(Animation):
         return self._mask[random.randint(0, (len(self._mask) - 1))]
 
     def draw(self):
-        self._pixels = [self._random_in_mask() for _ in range(self._num_sparkles)]
-        for pixel in self._pixels:
-            self.pixel_object[pixel] = self._sparkle_color
-
-    def after_draw(self):
-        self.show()
         for pixel in self._pixels:
             self.pixel_object[pixel % self._num_pixels] = self._half_color
             if (pixel + 1) % self._num_pixels in self._mask:
                 self.pixel_object[(pixel + 1) % self._num_pixels] = self._dim_color
+        self._pixels = [self._random_in_mask() for _ in range(self._num_sparkles)]
+        for pixel in self._pixels:
+            self.pixel_object[pixel] = self._sparkle_color

--- a/adafruit_led_animation/animation/sparklepulse.py
+++ b/adafruit_led_animation/animation/sparklepulse.py
@@ -64,10 +64,8 @@ class SparklePulse(Sparkle):
 
     def _set_color(self, color):
         self._color = color
+        super()._set_color(color)
 
     def draw(self):
         self._sparkle_color = next(self._generator)
         super().draw()
-
-    def after_draw(self):
-        self.show()


### PR DESCRIPTION
The Sparkle animation uses `after_draw` to setup the pixels currently being sparkled for the next frame, assuming `show()` will not be called until then. It also calls `show()` itself first to show the changes made in `draw()`.

The problem is that `animate()` already calls `show()` after calling draw **and** after_draw. So the frame where the sparkle should show is actually "skipped": it only briefly appears instead of staying for a frame according to the speed parameter. The refactor from PR #23 changed the protocol where animations should no longer call `show()` themselves.

We can't change `after_draw` to be called after the call to `show()` in `animate()`, because it will break for example on animation groups using the same strip: if another animation triggers a `show()`, it will show the next frame of the sparkle prematurely. It also makes the protocol less predictable in general.

This PR drops `after_draw()` altogether and instead does everything in `draw()`.

I don't think there is a need to preserve backwards compatibility with potential 3rd party animations using it, since it can't have worked properly since #23.