### PR TITLE
broke out animate() logic to guarantee each item calls animate

### DIFF
--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -157,7 +157,6 @@ class AnimationGroup:
             if item.animate(show):
                 ret=True
         return ret
-        #return any(item.animate(show) for item in self._members)
 
     @property
     def color(self):

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -152,10 +152,10 @@ class AnimationGroup:
                         member.show()
             return result
 
-        ret=False
+        ret = False
         for item in self._members:
             if item.animate(show):
-                ret=True
+                ret = True
         return ret
 
     @property

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -152,7 +152,12 @@ class AnimationGroup:
                         member.show()
             return result
 
-        return any(item.animate(show) for item in self._members)
+        ret=False
+        for item in self._members:
+            if item.animate(show):
+                ret=True
+        return ret
+        #return any(item.animate(show) for item in self._members)
 
     @property
     def color(self):


### PR DESCRIPTION
using any() in the animate() method short circuits upon the first successful animate. this prevents teh rest of the items from running animate() and results in sporadic animation dependent on timing of next_update

from #98 