### PR TITLE
sequence: Add a function to play the previous animation

### DIFF
--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -179,6 +179,13 @@ class AnimationSequence:
             self.on_cycle_complete()
         self.activate(current % len(self._members))
 
+    def previous(self):
+        """
+        Jump to the previous animation.
+        """
+        current = self._current - 1
+        self.activate(current % len(self._members))
+
     def random(self):
         """
         Jump to a random animation.


### PR DESCRIPTION
If we treat a Sequence as a list of animations that we switch between manually, then having a `previous` function to counteract `next` would be great :)