### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_led_animation/animation/chase.py
+++ b/adafruit_led_animation/animation/chase.py
@@ -111,7 +111,8 @@ class Chase(Animation):
         """
         return self.color
 
-    def space_color(self, n, pixel_no=0):  # pylint: disable=unused-argument
+    @staticmethod
+    def space_color(n, pixel_no=0):  # pylint: disable=unused-argument
         """
         Generate the spacing color for the n'th bar_color in the Chase
 


### PR DESCRIPTION
Fixed the following `pylint` errors:

```
************* Module adafruit_led_animation.animation.chase
Error: adafruit_led_animation/animation/chase.py:114:4: R6301: Method could be a function (no-self-use)
```