### PR TITLE
adding multicolor comet animation

### DIFF
--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -42,6 +42,8 @@ class Comet(Animation):
                             maximum of the length of the ``pixel_object``.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
     :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
+    :param Optional[string] name: A human-readable name for the Animation.
+                                  Used by the to string function.
     :param bool ring: Ring mode.  Defaults to ``False``.
     """
 

--- a/adafruit_led_animation/animation/multicolor_comet.py
+++ b/adafruit_led_animation/animation/multicolor_comet.py
@@ -42,6 +42,8 @@ class MulticolorComet(Comet):
                             maximum of the length of the ``pixel_object``.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
     :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
+    :param Optional[string] name: A human-readable name for the Animation.
+                                  Used by the to string function.
     :param bool ring: Ring mode.  Defaults to ``False``.
     :param bool off_pixels: Turn pixels off after the animation passes them. Defaults to ``True``.
                             Setting to False will result in all pixels not currently in the comet
@@ -54,6 +56,7 @@ class MulticolorComet(Comet):
         pixel_object,
         speed,
         colors,
+        *,
         tail_length=0,
         reverse=False,
         bounce=False,

--- a/adafruit_led_animation/animation/multicolor_comet.py
+++ b/adafruit_led_animation/animation/multicolor_comet.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2022 Tim Cocks
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_led_animation.animation.multicolor_comet`
+================================================================================
+
+Multi-color Comet animation for CircuitPython helper library for LED animations.
+
+* Author(s): Kattni Rembor, Tim Cocks
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Adafruit NeoPixels <https://www.adafruit.com/category/168>`_
+* `Adafruit DotStars <https://www.adafruit.com/category/885>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://circuitpython.org/downloads
+
+
+"""
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.color import BLACK
+
+
+class MulticolorComet(Comet):
+    """
+    A multi-color comet animation.
+
+    :param pixel_object: The initialised LED object.
+    :param float speed: Animation speed in seconds, e.g. ``0.1``.
+    :param colors: Animation colors in a list or tuple of entries in
+                            ``(r, g, b)`` tuple, or ``0x000000`` hex format.
+    :param int tail_length: The length of the comet. Defaults to 25% of the length of the
+                            ``pixel_object``. Automatically compensates for a minimum of 2 and a
+                            maximum of the length of the ``pixel_object``.
+    :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
+    :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
+    :param bool ring: Ring mode.  Defaults to ``False``.
+    :param bool off_pixels: Turn pixels off after the animation passes them. Defaults to ``True``.
+                            Setting to False will result in all pixels not currently in the comet
+                            to remain on and set to a color after the comet passes.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    def __init__(
+        self,
+        pixel_object,
+        speed,
+        colors,
+        tail_length=0,
+        reverse=False,
+        bounce=False,
+        name=None,
+        ring=False,
+        off_pixels=True,
+    ):
+        if tail_length == 0:
+            tail_length = len(pixel_object) // 4
+        if bounce and ring:
+            raise ValueError("Cannot combine bounce and ring mode")
+        self.bounce = bounce
+        self._reverse = reverse
+        self._initial_reverse = reverse
+        self._tail_length = tail_length
+
+        self._comet_colors = None
+
+        self._num_pixels = len(pixel_object)
+        self._direction = -1 if reverse else 1
+        self._left_side = -self._tail_length
+        self._right_side = self._num_pixels
+        self._tail_start = 0
+        self._ring = ring
+        self._colors = colors
+        if colors is None or len(colors) < 2:
+            raise ValueError("Must pass at least two colors.")
+
+        self._off_pixels = off_pixels
+        if ring:
+            self._left_side = 0
+        self.reset()
+        super().__init__(
+            pixel_object,
+            speed,
+            0x0,
+            name=name,
+            tail_length=tail_length,
+            bounce=bounce,
+            ring=ring,
+            reverse=reverse,
+        )
+
+    on_cycle_complete_supported = True
+
+    def _set_color(self, color):
+        if self._off_pixels:
+            self._comet_colors = [BLACK]
+        else:
+            self._comet_colors = []
+
+        for n in range(self._tail_length):
+            _float_index = ((len(self._colors)) / self._tail_length) * n
+            _color_index = int(_float_index)
+            self._comet_colors.append(self._colors[_color_index])

--- a/examples/led_animation_multicolor_comet.py
+++ b/examples/led_animation_multicolor_comet.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2022 Tim Cocks
+#
+# SPDX-License-Identifier: MIT
+"""
+This example animates a red, yellow, and green gradient comet that bounces
+from end to end of the strip.
+
+For QT Py Haxpress and a NeoPixel strip. Update pixel_pin and pixel_num to match your wiring if
+using a different board or form of NeoPixels.
+
+This example will run on SAMD21 (M0) Express boards (such as Circuit Playground Express or QT Py
+Haxpress), but not on SAMD21 non-Express boards (such as QT Py or Trinket).
+"""
+import board
+import neopixel
+from adafruit_led_animation.animation.multicolor_comet import MulticolorComet
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D9
+# Update to match the number of NeoPixels you have connected
+pixel_num = 96
+brightness = 0.02
+
+pixels = neopixel.NeoPixel(
+    pixel_pin,
+    pixel_num,
+    brightness=brightness,
+    auto_write=True,
+    pixel_order=neopixel.RGB,
+)
+
+comet_colors = [
+    0xFF0000,
+    0xFD2000,
+    0xF93E00,
+    0xF45B00,
+    0xEC7500,
+    0xE28D00,
+    0xD5A200,
+    0xC6B500,
+    0xB5C600,
+    0xA2D500,
+    0x8DE200,
+    0x75EC00,
+    0x5BF400,
+    0x3EF900,
+    0x20FD00,
+    0x00FF00,
+]
+
+
+comet = MulticolorComet(
+    pixels,
+    colors=comet_colors,
+    speed=0.01,
+    tail_length=20,
+    bounce=True,
+    ring=False,
+    reverse=False,
+)
+
+while True:
+    comet.animate()


### PR DESCRIPTION
This change creates a new MulticolorComet class that functions similar to the existing Comet except that it allows user to specify multiple colors and the comet will contain all of them rather than a single color that fades to black. It will try to evenly spread the colors specified across the length of the tail.

A new example is provided that illustrates usage of the animation. It was tested with Feather M4 8.0.0 beta.5 and a 96 neopixel strip