### PR TITLE
adding multicolor chase animation

### DIFF
--- a/adafruit_led_animation/animation/multicolor_chase.py
+++ b/adafruit_led_animation/animation/multicolor_chase.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2020 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_led_animation.animation.rainbowchase`
+================================================================================
+
+Rainbow chase animation for CircuitPython helper library for LED animations.
+
+* Author(s): Kattni Rembor
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Adafruit NeoPixels <https://www.adafruit.com/category/168>`_
+* `Adafruit DotStars <https://www.adafruit.com/category/885>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://circuitpython.org/downloads
+
+
+"""
+
+from adafruit_led_animation.animation.chase import Chase
+
+
+class MulticolorChase(Chase):
+    """
+    Chase pixels in one direction, like a theater marquee but with rainbows!
+
+    :param pixel_object: The initialised LED object.
+    :param float speed: Animation speed rate in seconds, e.g. ``0.1``.
+    :param colors: Animation colors in a list or tuple of entries in
+                            ``(r, g, b)`` tuple, or ``0x000000`` hex format.
+    :param size: Number of pixels to turn on in a row.
+    :param spacing: Number of pixels to turn off in a row.
+    :param reverse: Reverse direction of movement.
+
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, pixel_object, speed, colors, size=2, spacing=3, reverse=False, name=None
+    ):
+
+        self._colors = colors
+        self._color_idx = 0
+        super().__init__(pixel_object, speed, 0, size, spacing, reverse, name)
+
+    def bar_color(self, n, pixel_no=0):
+        return self._colors[self._color_idx - (n % len(self._colors))]
+
+    def on_cycle_complete(self):
+        self._color_idx = (self._color_idx + self._direction) % len(self._colors)
+        super().on_cycle_complete()

--- a/adafruit_led_animation/animation/multicolor_chase.py
+++ b/adafruit_led_animation/animation/multicolor_chase.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Kattni Rembor for Adafruit Industries
+# SPDX-FileCopyrightText: 2022 Tim Cocks
 #
 # SPDX-License-Identifier: MIT
 
@@ -8,7 +8,7 @@
 
 Rainbow chase animation for CircuitPython helper library for LED animations.
 
-* Author(s): Kattni Rembor
+* Author(s): Kattni Rembor, Tim Cocks
 
 Implementation Notes
 --------------------

--- a/examples/led_animation_multicolor_chase.py
+++ b/examples/led_animation_multicolor_chase.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2022 Tim Cocks
+#
+# SPDX-License-Identifier: MIT
+"""
+This example animates a red, yellow, and green chase animation.
+
+For QT Py Haxpress and a NeoPixel strip. Update pixel_pin and pixel_num to match your wiring if
+using a different board or form of NeoPixels.
+
+This example will run on SAMD21 (M0) Express boards (such as Circuit Playground Express or QT Py
+Haxpress), but not on SAMD21 non-Express boards (such as QT Py or Trinket).
+"""
+import board
+import neopixel
+from adafruit_led_animation.animation.multicolor_chase import MulticolorChase
+
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.D9
+# Update to match the number of NeoPixels you have connected
+pixel_num = 96
+brightness = 0.03
+
+pixels = neopixel.NeoPixel(
+    pixel_pin,
+    pixel_num,
+    brightness=brightness,
+    auto_write=True,
+    pixel_order=neopixel.RGB,
+)
+
+gradient_colors = [
+    0xFF0000,
+    0xFD2000,
+    0xF93E00,
+    0xF45B00,
+    0xEC7500,
+    0xE28D00,
+    0xD5A200,
+    0xC6B500,
+    0xB5C600,
+    0xA2D500,
+    0x8DE200,
+    0x75EC00,
+    0x5BF400,
+    0x3EF900,
+    0x20FD00,
+    0x00FF00,
+]
+
+chase = MulticolorChase(
+    pixels,
+    speed=0.05,
+    size=3,
+    spacing=8,
+    colors=(0xFF0000, 0xFFFF00, 0x00FF00),
+    # colors=gradient_colors, # try this one for smoother color transition
+)
+
+while True:
+    chase.animate()


### PR DESCRIPTION
This change adds a multi color chase animation and an example that illustrates how to use it. 

The animation was tested on a Feather M4 8.0.0 beta.5 with a 96 neopixel strip.