### PR TITLE
rainbowcomet: add missing arg initing base class

### DIFF
--- a/adafruit_led_animation/animation/rainbowcomet.py
+++ b/adafruit_led_animation/animation/rainbowcomet.py
@@ -65,7 +65,7 @@ class RainbowComet(Comet):
             self._colorwheel_step = step
         self._colorwheel_offset = colorwheel_offset
         super().__init__(
-            pixel_object, speed, 0, tail_length, reverse, bounce, name, ring
+            pixel_object, speed, 0, 0, tail_length, reverse, bounce, name, ring
         )
 
     def _set_color(self, color):


### PR DESCRIPTION
In RainbowComet, the call to `super().__init__()` was missing the `background_color` argument. This caused strange effects when non-default arguments were passed.

For example, setting `reverse=True` resulted a red comet with a tail length of 1, and setting `bounce=True` resulted in a reversed rainbow comet.
