### PR TITLE
fix doc of `bounce`

### DIFF
--- a/adafruit_led_animation/animation/comet.py
+++ b/adafruit_led_animation/animation/comet.py
@@ -41,7 +41,7 @@ class Comet(Animation):
                             ``pixel_object``. Automatically compensates for a minimum of 2 and a
                             maximum of the length of the ``pixel_object``.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
-    :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
+    :param bool bounce: Comet will bounce back and forth. Defaults to ``False``.
     :param bool ring: Ring mode.  Defaults to ``False``.
     """
 

--- a/adafruit_led_animation/animation/rainbowcomet.py
+++ b/adafruit_led_animation/animation/rainbowcomet.py
@@ -40,7 +40,7 @@ class RainbowComet(Comet):
                             pixels present in the pixel object, e.g. if the strip is 30 pixels
                             long, the ``tail_length`` cannot exceed 30 pixels.
     :param bool reverse: Animates the comet in the reverse order. Defaults to ``False``.
-    :param bool bounce: Comet will bounce back and forth. Defaults to ``True``.
+    :param bool bounce: Comet will bounce back and forth. Defaults to ``False``.
     :param int colorwheel_offset: Offset from start of colorwheel (0-255).
     :param int step: Colorwheel step (defaults to automatic).
     :param bool ring: Ring mode.  Defaults to ``False``.


### PR DESCRIPTION
Fix documentation of the default `bounce` value for `Comet` and `RainbowComet`.
