### PR TITLE
Group perf update

### DIFF
--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -154,16 +154,14 @@ class AnimationGroup:
 
         # improve performance of non-synced animations by only calling show on the last member
         ret = False
-        pos = 1
         num_members = len(self._members)
-        for item in self._members:
-            if pos == num_members:
+        for index, item in enumerate(self._members):
+            if index == num_members - 1:
                 if item.animate(show):
                     ret = True
             else:
                 if item.animate(False):
                     ret = True
-                pos += 1
         return ret
 
     @property

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -152,7 +152,7 @@ class AnimationGroup:
                         member.show()
             return result
 
-        #improve performance of non-synced animations by only calling show on the last member
+        # improve performance of non-synced animations by only calling show on the last member
         ret = False
         pos = 1
         num_members = len(self._members)

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -163,7 +163,7 @@ class AnimationGroup:
             else:
                 if item.animate(False):
                     ret = True
-                pos = pos + 1
+                pos += 1
         return ret
 
     @property

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -152,10 +152,18 @@ class AnimationGroup:
                         member.show()
             return result
 
+        #improve performance of non-synced animations by only calling show on the last member
         ret = False
+        pos = 1
+        num_members = len(self._members)
         for item in self._members:
-            if item.animate(show):
-                ret = True
+            if pos == num_members:
+                if item.animate(show):
+                    ret = True
+            else:
+                if item.animate(False):
+                    ret = True
+                pos = pos + 1
         return ret
 
     @property


### PR DESCRIPTION
I have many Animations in a AnimationGroup. On my Pi Zero 2 W, I saw considerable performance issues when calling the animate function on my AnimationGroup. I discovered that the AnimationGroup.animate was calling each member items animate function with show=true. This results in drawing for EVERY item in the group. By calling show only on the last item in the Group, we improve performance only drawing once. Effectively, this improves from O(n^2) to O(n) in my use-case.