### PR TITLE
ColorCycle accepts start color

### DIFF
--- a/adafruit_led_animation/animation/colorcycle.py
+++ b/adafruit_led_animation/animation/colorcycle.py
@@ -40,7 +40,7 @@ class ColorCycle(Animation):
                    format. Defaults to a rainbow color cycle.
     :param start_color: An index (from 0) for which color to start from. Default 0 (first color).
     """
-    
+
     # pylint: disable=too-many-arguments
     def __init__(self, pixel_object, speed, colors=RAINBOW, start_color=0, name=None):
         self.colors = colors
@@ -61,7 +61,7 @@ class ColorCycle(Animation):
             self._color = self.colors[index]
             yield
             index = (index + 1) % len(self.colors)
-            if index == 0:
+            if index == start_color:
                 self.cycle_complete = True
 
     def reset(self):

--- a/adafruit_led_animation/animation/colorcycle.py
+++ b/adafruit_led_animation/animation/colorcycle.py
@@ -38,11 +38,13 @@ class ColorCycle(Animation):
     :param float speed: Animation speed in seconds, e.g. ``0.1``.
     :param colors: A list of colors to cycle through in ``(r, g, b)`` tuple, or ``0x000000`` hex
                    format. Defaults to a rainbow color cycle.
-    :param start_color: An index (from 0) for which color to start from. Default 0 (first color given).
+    :param start_color: An index (from 0) for which color to start from. Default 0 (first color).
     """
-
+    
+    # pylint: disable=too-many-arguments
     def __init__(self, pixel_object, speed, colors=RAINBOW, start_color=0, name=None):
         self.colors = colors
+        self.start_color = start_color
         super().__init__(pixel_object, speed, colors[start_color], name=name)
         self._generator = self._color_generator(start_color)
         next(self._generator)
@@ -66,4 +68,4 @@ class ColorCycle(Animation):
         """
         Resets to the first color.
         """
-        self._generator = self._color_generator()
+        self._generator = self._color_generator(self.start_color)

--- a/adafruit_led_animation/animation/colorcycle.py
+++ b/adafruit_led_animation/animation/colorcycle.py
@@ -42,7 +42,7 @@ class ColorCycle(Animation):
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, pixel_object, speed, colors=RAINBOW, start_color=0, name=None):
+    def __init__(self, pixel_object, speed, colors=RAINBOW, name=None, start_color=0):
         self.colors = colors
         self.start_color = start_color
         super().__init__(pixel_object, speed, colors[start_color], name=name)

--- a/adafruit_led_animation/animation/colorcycle.py
+++ b/adafruit_led_animation/animation/colorcycle.py
@@ -38,12 +38,13 @@ class ColorCycle(Animation):
     :param float speed: Animation speed in seconds, e.g. ``0.1``.
     :param colors: A list of colors to cycle through in ``(r, g, b)`` tuple, or ``0x000000`` hex
                    format. Defaults to a rainbow color cycle.
+    :param start_color: An index (from 0) for which color to start from. Default 0 (first color given).
     """
 
-    def __init__(self, pixel_object, speed, colors=RAINBOW, name=None):
+    def __init__(self, pixel_object, speed, colors=RAINBOW, start_color=0, name=None):
         self.colors = colors
-        super().__init__(pixel_object, speed, colors[0], name=name)
-        self._generator = self._color_generator()
+        super().__init__(pixel_object, speed, colors[start_color], name=name)
+        self._generator = self._color_generator(start_color)
         next(self._generator)
 
     on_cycle_complete_supported = True
@@ -52,8 +53,8 @@ class ColorCycle(Animation):
         self.pixel_object.fill(self.color)
         next(self._generator)
 
-    def _color_generator(self):
-        index = 0
+    def _color_generator(self, start_color):
+        index = start_color
         while True:
             self._color = self.colors[index]
             yield


### PR DESCRIPTION
ColorCycle accepts start color. Enables "candy-cane"-like animations; e.g:
AnimationGroup with
[ColorCycle(strips[0], speed=5, colors=[color.WHITE, color.RED, color.GREEN, color.BLACK], start_color=0),
         ColorCycle(strips[1], speed=5, colors=[color.WHITE, color.RED, color.GREEN, color.BLACK], start_color=1),
         ColorCycle(strips[2], speed=5, colors=[color.WHITE, color.RED, color.GREEN, color.BLACK], start_color=2),
         ColorCycle(strips[3], speed=5, colors=[color.WHITE, color.RED, color.GREEN, color.BLACK], start_color=3)
         ]