### PR TITLE
Restores min_intensity and max_intensity for Pulse animation and smoother transition option

### DIFF
--- a/adafruit_led_animation/animation/pulse.py
+++ b/adafruit_led_animation/animation/pulse.py
@@ -37,12 +37,18 @@ class Pulse(Animation):
     :param float speed: Animation refresh rate in seconds, e.g. ``0.1``.
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
     :param period: Period to pulse the LEDs over.  Default 5.
+    :param breath: Duration to hold minimum and maximum intensity levels. Default 0.
+    :param min_intensity: Lowest brightness level of the pulse. Default 0.
+    :param max_intensity: Highest brightness elvel of the pulse. Default 1.
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, pixel_object, speed, color, period=5, name=None):
+    def __init__(self, pixel_object, speed, color, period=5, breath=0, min_intensity=0, max_intensity=1, name=None):
         super().__init__(pixel_object, speed, color, name=name)
         self._period = period
+        self._breath = breath
+        self._min_intensity = min_intensity
+        self._max_intensity = max_intensity
         self._generator = None
         self.reset()
 

--- a/adafruit_led_animation/animation/pulse.py
+++ b/adafruit_led_animation/animation/pulse.py
@@ -43,7 +43,17 @@ class Pulse(Animation):
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, pixel_object, speed, color, period=5, breath=0, min_intensity=0, max_intensity=1, name=None):
+    def __init__(
+        self,
+        pixel_object,
+        speed,
+        color,
+        period=5,
+        breath=0,
+        min_intensity=0,
+        max_intensity=1,
+        name=None,
+    ):
         super().__init__(pixel_object, speed, color, name=name)
         self._period = period
         self.breath = breath

--- a/adafruit_led_animation/animation/pulse.py
+++ b/adafruit_led_animation/animation/pulse.py
@@ -46,9 +46,9 @@ class Pulse(Animation):
     def __init__(self, pixel_object, speed, color, period=5, breath=0, min_intensity=0, max_intensity=1, name=None):
         super().__init__(pixel_object, speed, color, name=name)
         self._period = period
-        self._breath = breath
-        self._min_intensity = min_intensity
-        self._max_intensity = max_intensity
+        self.breath = breath
+        self.min_intensity = min_intensity
+        self.max_intensity = max_intensity
         self._generator = None
         self.reset()
 

--- a/adafruit_led_animation/animation/sparklepulse.py
+++ b/adafruit_led_animation/animation/sparklepulse.py
@@ -55,10 +55,10 @@ class SparklePulse(Sparkle):
         min_intensity=0,
         name=None,
     ):
-        self._max_intensity = max_intensity
-        self._min_intensity = min_intensity
         self._period = period
-        self._breath = breath
+        self.breath = breath
+        self.min_intensity = min_intensity
+        self.max_intensity = max_intensity
         dotstar = len(pixel_object) == 4 and isinstance(pixel_object[0][-1], float)
         super().__init__(
             pixel_object, speed=speed, color=color, num_sparkles=1, name=name

--- a/adafruit_led_animation/animation/sparklepulse.py
+++ b/adafruit_led_animation/animation/sparklepulse.py
@@ -38,6 +38,7 @@ class SparklePulse(Sparkle):
     :param int speed: Animation refresh rate in seconds, e.g. ``0.1``.
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
     :param period: Period to pulse the LEDs over.  Default 5.
+    :param breath: Duration to hold minimum and maximum intensity. Default 0.
     :param max_intensity: The maximum intensity to pulse, between 0 and 1.0.  Default 1.
     :param min_intensity: The minimum intensity to pulse, between 0 and 1.0.  Default 0.
     """
@@ -49,6 +50,7 @@ class SparklePulse(Sparkle):
         speed,
         color,
         period=5,
+        breath=0,
         max_intensity=1,
         min_intensity=0,
         name=None,
@@ -56,6 +58,7 @@ class SparklePulse(Sparkle):
         self._max_intensity = max_intensity
         self._min_intensity = min_intensity
         self._period = period
+        self._breath = breath
         dotstar = len(pixel_object) == 4 and isinstance(pixel_object[0][-1], float)
         super().__init__(
             pixel_object, speed=speed, color=color, num_sparkles=1, name=name

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -322,7 +322,8 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
     :param animation_object: An animation object to interact with.
     :param dotstar_pwm: Whether to use the dostar per pixel PWM value for brightness control.
     """
-    period = int(period * MS_PER_SECOND)
+    period = int((period + (animation_object._breath * 2)) * MS_PER_SECOND)
+    breath = int(animation_object._breath * MS_PER_SECOND)
     half_period = period // 2
 
     last_update = monotonic_ms()
@@ -338,7 +339,11 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         last_pos = pos
         if pos > half_period:
             pos = period - pos
-        intensity = pos / half_period
+        intensity = animation_object._min_intensity + ((pos / (half_period - breath)) * (animation_object._max_intensity - animation_object._min_intensity))
+        if pos < half_period and pos > (half_period - breath):
+            intensity = animation_object._max_intensity
+        if pos > (period - breath):
+            intensity = animation_object._min_intensity
         if dotstar_pwm:
             fill_color = (
                 animation_object.color[0],

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -323,7 +323,7 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
     :param dotstar_pwm: Whether to use the dostar per pixel PWM value for brightness control.
     """
     period = int((period + (animation_object.breath * 2)) * MS_PER_SECOND)
-    breath = int(animation_object.breath * MS_PER_SECOND)
+    half_breath = int(animation_object.breath * MS_PER_SECOND // 2)
     half_period = period // 2
 
     last_update = monotonic_ms()
@@ -339,12 +339,12 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         last_pos = pos
         if pos > half_period:
             pos = period - pos
-        if pos < half_period and pos > (half_period - breath):
-            intensity = animation_object.max_intensity
-        elif pos > (period - breath):
+        if pos < half_breath:
             intensity = animation_object.min_intensity
+        elif pos > (half_period - half_breath):
+            intensity = animation_object.max_intensity
         else:
-            intensity = animation_object.min_intensity + ((pos / (half_period - breath)) * (animation_object.max_intensity - animation_object.min_intensity))
+            intensity = animation_object.min_intensity + (((pos - half_breath) / (half_period - (half_breath * 2))) * (animation_object.max_intensity - animation_object.min_intensity))
         if dotstar_pwm:
             fill_color = (
                 animation_object.color[0],

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -344,7 +344,10 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         elif pos > (half_period - half_breath):
             intensity = animation_object.max_intensity
         else:
-            intensity = animation_object.min_intensity + (((pos - half_breath) / (half_period - (half_breath * 2))) * (animation_object.max_intensity - animation_object.min_intensity))
+            intensity = animation_object.min_intensity + (
+                ((pos - half_breath) / (half_period - (half_breath * 2)))
+                * (animation_object.max_intensity - animation_object.min_intensity)
+            )
         if dotstar_pwm:
             fill_color = (
                 animation_object.color[0],

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -339,7 +339,7 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         last_pos = pos
         if pos > half_period:
             pos = period - pos
-        if pos < half_period and pox > (half_period - breath):
+        if pos < half_period and pos > (half_period - breath):
             intensity = animation_object.max_intensity
         elif pos > (period - breath):
             intensity = animation_object.min_intensity

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -339,11 +339,12 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         last_pos = pos
         if pos > half_period:
             pos = period - pos
-        intensity = animation_object.min_intensity + ((pos / (half_period - breath)) * (animation_object.max_intensity - animation_object.min_intensity))
-        if pos < half_period and pos > (half_period - breath):
+        if pos < half_period and pox > (half_period - breath):
             intensity = animation_object.max_intensity
-        if pos > (period - breath):
+        elif pos > (period - breath):
             intensity = animation_object.min_intensity
+        else:
+            intensity = animation_object.min_intensity + ((pos / (half_period - breath)) * (animation_object.max_intensity - animation_object.min_intensity))
         if dotstar_pwm:
             fill_color = (
                 animation_object.color[0],

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -322,8 +322,8 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
     :param animation_object: An animation object to interact with.
     :param dotstar_pwm: Whether to use the dostar per pixel PWM value for brightness control.
     """
-    period = int((period + (animation_object._breath * 2)) * MS_PER_SECOND)
-    breath = int(animation_object._breath * MS_PER_SECOND)
+    period = int((period + (animation_object.breath * 2)) * MS_PER_SECOND)
+    breath = int(animation_object.breath * MS_PER_SECOND)
     half_period = period // 2
 
     last_update = monotonic_ms()
@@ -339,11 +339,11 @@ def pulse_generator(period: float, animation_object, dotstar_pwm=False):
         last_pos = pos
         if pos > half_period:
             pos = period - pos
-        intensity = animation_object._min_intensity + ((pos / (half_period - breath)) * (animation_object._max_intensity - animation_object._min_intensity))
+        intensity = animation_object.min_intensity + ((pos / (half_period - breath)) * (animation_object.max_intensity - animation_object.min_intensity))
         if pos < half_period and pos > (half_period - breath):
-            intensity = animation_object._max_intensity
+            intensity = animation_object.max_intensity
         if pos > (period - breath):
-            intensity = animation_object._min_intensity
+            intensity = animation_object.min_intensity
         if dotstar_pwm:
             fill_color = (
                 animation_object.color[0],


### PR DESCRIPTION
Restores support for the min_intensity and max_intensity values on both the Pulse and SparklePulse animations. Also introduces a 'breath' value (default 0) to give a duration to hold the minimum and maximum intensity during the animation for smoother transitions in pulse direction.
eg.
Pulse(led_strip, speed=0.01, color=(255, 255, 255), period=5, breath=0.5, min_intensity=0.3, max_intensity=0.8)