### PR TITLE
public property for rainbow.period

### DIFF
--- a/adafruit_led_animation/animation/rainbow.py
+++ b/adafruit_led_animation/animation/rainbow.py
@@ -127,7 +127,7 @@ class Rainbow(Animation):
     @property
     def period(self) -> float:
         """
-         Period to cycle the rainbow over in seconds.
+        Period to cycle the rainbow over in seconds.
         """
         return self._period
 

--- a/adafruit_led_animation/animation/rainbow.py
+++ b/adafruit_led_animation/animation/rainbow.py
@@ -126,6 +126,9 @@ class Rainbow(Animation):
 
     @property
     def period(self) -> float:
+        """
+         Period to cycle the rainbow over in seconds.
+        """
         return self._period
 
     @period.setter

--- a/adafruit_led_animation/animation/rainbow.py
+++ b/adafruit_led_animation/animation/rainbow.py
@@ -123,3 +123,12 @@ class Rainbow(Animation):
         Resets the animation.
         """
         self._generator = self._color_wheel_generator()
+
+    @property
+    def period(self) -> float:
+        return self._period
+
+    @period.setter
+    def period(self, new_value: float) -> None:
+        self._period = new_value
+        self.reset()


### PR DESCRIPTION
@ladyada 
Resolves: #113 

`period` was providing as an arg to init and then stored in private field. This allows it to be accessed and updated more easily, with the requisite call to `reset()` to make it have an effect after being updated. 