### PR TITLE
add period property to pulse and sparklepulse, fix typo

### DIFF
--- a/adafruit_led_animation/animation/pulse.py
+++ b/adafruit_led_animation/animation/pulse.py
@@ -39,7 +39,7 @@ class Pulse(Animation):
     :param period: Period to pulse the LEDs over.  Default 5.
     :param breath: Duration to hold minimum and maximum intensity levels. Default 0.
     :param min_intensity: Lowest brightness level of the pulse. Default 0.
-    :param max_intensity: Highest brightness elvel of the pulse. Default 1.
+    :param max_intensity: Highest brightness level of the pulse. Default 1.
     """
 
     # pylint: disable=too-many-arguments
@@ -80,3 +80,15 @@ class Pulse(Animation):
         )
 
         self._generator = pulse_generator(self._period, self, dotstar_pwm=dotstar)
+
+    @property
+    def period(self):
+        """
+        Period to pulse the LEDs over in seconds
+        """
+        return self._period
+
+    @period.setter
+    def period(self, new_value):
+        self._period = new_value
+        self.reset()

--- a/adafruit_led_animation/animation/sparklepulse.py
+++ b/adafruit_led_animation/animation/sparklepulse.py
@@ -74,3 +74,21 @@ class SparklePulse(Sparkle):
 
     def after_draw(self):
         self.show()
+
+    @property
+    def period(self):
+        """
+        Period to pulse the LEDs over in seconds
+        """
+        return self._period
+
+    @period.setter
+    def period(self, new_value):
+        self._period = new_value
+        self.reset()
+
+    def reset(self):
+        dotstar = len(self.pixel_object) == 4 and isinstance(
+            self.pixel_object[0][-1], float
+        )
+        self._generator = pulse_generator(self._period, self, dotstar_pwm=dotstar)


### PR DESCRIPTION
@ladyada 
I think this is the feature that was being request by this comment: https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation/issues/65#issuecomment-1581786622

They called it `speed` instead of period, but I found that `speed` already is a property on Animation super class and it is already settable and it does already affect the animation that is running. Both `speed` and `period` affect the behavior of the animation in similar ways for some of the animations at least. 

