### PR TITLE
Blink with user color selected background

### DIFF
--- a/adafruit_led_animation/animation/blink.py
+++ b/adafruit_led_animation/animation/blink.py
@@ -37,10 +37,17 @@ class Blink(ColorCycle):
     :param pixel_object: The initialised LED object.
     :param float speed: Animation speed in seconds, e.g. ``0.1``.
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
+    :param background_color: Background color in ``(r, g, b)`` tuple, or ``0x000000`` hex format. Defaults to BLACK.
+    :param name: A human-readable name for the Animation. Used by the string function.
     """
 
-    def __init__(self, pixel_object, speed, color, name=None):
-        super().__init__(pixel_object, speed, [color, BLACK], name=name)
+    def __init__(
+        self, pixel_object, speed, color, background_color=BLACK, name=None
+    ):
+        self._background_color = background_color
+        super().__init__(
+            pixel_object, speed, [color, background_color], name=name
+        )
 
     def _set_color(self, color):
-        self.colors = [color, BLACK]
+        self.colors = [color, self._background_color]

--- a/adafruit_led_animation/animation/blink.py
+++ b/adafruit_led_animation/animation/blink.py
@@ -37,17 +37,15 @@ class Blink(ColorCycle):
     :param pixel_object: The initialised LED object.
     :param float speed: Animation speed in seconds, e.g. ``0.1``.
     :param color: Animation color in ``(r, g, b)`` tuple, or ``0x000000`` hex format.
-    :param background_color: Background color in ``(r, g, b)`` tuple, or ``0x000000`` hex format. Defaults to BLACK.
+    :param background_color: Background color in ``(r, g, b)`` tuple, or ``0x000000``
+     hex format. Defaults to BLACK.
     :param name: A human-readable name for the Animation. Used by the string function.
     """
 
-    def __init__(
-        self, pixel_object, speed, color, background_color=BLACK, name=None
-    ):
+    # pylint: disable=too-many-arguments
+    def __init__(self, pixel_object, speed, color, background_color=BLACK, name=None):
         self._background_color = background_color
-        super().__init__(
-            pixel_object, speed, [color, background_color], name=name
-        )
+        super().__init__(pixel_object, speed, [color, background_color], name=name)
 
     def _set_color(self, color):
         self.colors = [color, self._background_color]

--- a/adafruit_led_animation/animation/volume.py
+++ b/adafruit_led_animation/animation/volume.py
@@ -44,7 +44,13 @@ class Volume(Animation):
 
     # pylint: disable=too-many-arguments
     def __init__(
-        self, pixel_object, speed, brightest_color, decoder, max_volume=500, name=None
+        self,
+        pixel_object,
+        speed,
+        brightest_color,
+        decoder,
+        max_volume=500,
+        name=None,
     ):
         self._decoder = decoder
         self._num_pixels = len(pixel_object)
@@ -89,8 +95,15 @@ class Volume(Animation):
         )
 
         lit_pixels = int(
-            map_range(self._decoder.rms_level, 0, self._max_volume, 0, self._num_pixels)
+            map_range(
+                self._decoder.rms_level,
+                0,
+                self._max_volume,
+                0,
+                self._num_pixels,
+            )
         )
+        # pylint: disable=consider-using-min-builtin
         if lit_pixels > self._num_pixels:
             lit_pixels = self._num_pixels
 

--- a/adafruit_led_animation/sequence.py
+++ b/adafruit_led_animation/sequence.py
@@ -73,7 +73,7 @@ class AnimationSequence:
             animations.animate()
     """
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(
         self,
         *members,

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -61,6 +61,14 @@ Demonstrates the blink animation.
     :caption: examples/led_animation_blink.py
     :linenos:
 
+Blink with a selcted background color
+----------------------------------------
+Demonstrates the blink animation with an user defined background color.
+
+.. literalinclude:: ../examples/led_animation_blink_with_background.py
+    :caption: examples/led_animation_blink_with_background.py
+    :linenos:
+
 Comet
 -----
 

--- a/examples/led_animation_blink_with_background.py
+++ b/examples/led_animation_blink_with_background.py
@@ -21,9 +21,7 @@ pixel_pin = board.A3
 # Update to match the number of NeoPixels you have connected
 pixel_num = 30
 
-pixels = neopixel.NeoPixel(
-    pixel_pin, pixel_num, brightness=0.5, auto_write=False
-)
+pixels = neopixel.NeoPixel(pixel_pin, pixel_num, brightness=0.5, auto_write=False)
 
 blink = Blink(pixels, speed=0.5, color=PURPLE, background_color=YELLOW)
 

--- a/examples/led_animation_blink_with_background.py
+++ b/examples/led_animation_blink_with_background.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 Jose D. Montoya
+# SPDX-License-Identifier: MIT
+
+"""
+This example blinks the LEDs purple with a yellow background at a 0.5 second interval.
+
+For QT Py Haxpress and a NeoPixel strip. Update pixel_pin and pixel_num to match your wiring if
+using a different board or form of NeoPixels.
+
+This example will run on SAMD21 (M0) Express boards (such as Circuit Playground Express or QT Py
+Haxpress), but not on SAMD21 non-Express boards (such as QT Py or Trinket).
+"""
+import board
+import neopixel
+
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.color import PURPLE, YELLOW
+
+# Update to match the pin connected to your NeoPixels
+pixel_pin = board.A3
+# Update to match the number of NeoPixels you have connected
+pixel_num = 30
+
+pixels = neopixel.NeoPixel(
+    pixel_pin, pixel_num, brightness=0.5, auto_write=False
+)
+
+blink = Blink(pixels, speed=0.5, color=PURPLE, background_color=YELLOW)
+
+while True:
+    blink.animate()


### PR DESCRIPTION
A slight modification in the Blink animation, to allow the user to select the background color. This was hardcoded as BLACk in the original one.

Thanks.

I had to add some Py-lint disable calls, to make the linter happy