### PR TITLE
Add support for OpenMV/MicroPython

### DIFF
--- a/adafruit_led_animation/__init__.py
+++ b/adafruit_led_animation/__init__.py
@@ -28,13 +28,22 @@ try:
         return monotonic_ns() // NANOS_PER_MS
 
 except (ImportError, NotImplementedError):
-    import time
+    try:
+        from time import monotonic
 
-    def monotonic_ms():
-        """
-        Implementation of monotonic_ms for platforms without time.monotonic_ns
-        """
-        return int(time.monotonic() * MS_PER_SECOND)
+        def monotonic_ms():
+            """
+            Implementation of monotonic_ms for platforms without time.monotonic_ns
+            """
+            return int(monotonic() * MS_PER_SECOND)
+    except (ImportError, NotImplementedError):
+        from time import time_ns
+
+        def monotonic_ms():
+            """
+            Implementation of monotonic_ms for platforms without time.monotonic_ns or time.monotonic
+            """
+            return time_ns() // NANOS_PER_MS
 
 
 NANOS_PER_MS = const(1000000)

--- a/adafruit_led_animation/__init__.py
+++ b/adafruit_led_animation/__init__.py
@@ -36,6 +36,7 @@ except (ImportError, NotImplementedError):
             Implementation of monotonic_ms for platforms without time.monotonic_ns
             """
             return int(monotonic() * MS_PER_SECOND)
+
     except (ImportError, NotImplementedError):
         from time import time_ns
 

--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -41,7 +41,8 @@ class Animation:
     # pylint: disable=too-many-arguments
     def __init__(self, pixel_object, speed, color, peers=None, paused=False, name=None):
         self.pixel_object = pixel_object
-        self.pixel_object.auto_write = False
+        if hasattr(self.pixel_object, "auto_write"):
+            self.pixel_object.auto_write = False
         self._peers = [self] + peers if peers is not None else [self]
         self._speed_ms = 0
         self._color = None
@@ -116,7 +117,10 @@ class Animation:
         """
         Displays the updated pixels.  Called during animates with changes.
         """
-        self.pixel_object.show()
+        if hasattr(self.pixel_object, "show"):
+            self.pixel_object.show()
+        elif hasattr(self.pixel_object, "write"):
+            self.pixel_object.write()
 
     @property
     def peers(self):
@@ -154,7 +158,10 @@ class Animation:
         Fills the pixel object with a color.
         """
         self.pixel_object.fill(color)
-        self.pixel_object.show()
+        if hasattr(self.pixel_object, "show"):
+            self.pixel_object.show()
+        elif hasattr(self.pixel_object, "write"):
+            self.pixel_object.write()
 
     @property
     def color(self):

--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -29,6 +29,9 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation.git"
 
 from adafruit_led_animation import MS_PER_SECOND, monotonic_ms
+from adafruit_led_animation.helper import (
+    pixel_object_show, pixel_object_auto_write_set
+)
 
 
 class Animation:
@@ -41,8 +44,7 @@ class Animation:
     # pylint: disable=too-many-arguments
     def __init__(self, pixel_object, speed, color, peers=None, paused=False, name=None):
         self.pixel_object = pixel_object
-        if hasattr(self.pixel_object, "auto_write"):
-            self.pixel_object.auto_write = False
+        pixel_object_auto_write_set(pixel_object, False)
         self._peers = [self] + peers if peers is not None else [self]
         self._speed_ms = 0
         self._color = None
@@ -117,10 +119,7 @@ class Animation:
         """
         Displays the updated pixels.  Called during animates with changes.
         """
-        if hasattr(self.pixel_object, "show"):
-            self.pixel_object.show()
-        elif hasattr(self.pixel_object, "write"):
-            self.pixel_object.write()
+        pixel_object_show(self.pixel_object)
 
     @property
     def peers(self):
@@ -158,10 +157,7 @@ class Animation:
         Fills the pixel object with a color.
         """
         self.pixel_object.fill(color)
-        if hasattr(self.pixel_object, "show"):
-            self.pixel_object.show()
-        elif hasattr(self.pixel_object, "write"):
-            self.pixel_object.write()
+        pixel_object_show(self.pixel_object)
 
     @property
     def color(self):

--- a/adafruit_led_animation/animation/__init__.py
+++ b/adafruit_led_animation/animation/__init__.py
@@ -29,9 +29,7 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation.git"
 
 from adafruit_led_animation import MS_PER_SECOND, monotonic_ms
-from adafruit_led_animation.helper import (
-    pixel_object_show, pixel_object_auto_write_set
-)
+from adafruit_led_animation.helper import pixel_object_show, pixel_object_auto_write_set
 
 
 class Animation:

--- a/adafruit_led_animation/color.py
+++ b/adafruit_led_animation/color.py
@@ -29,7 +29,18 @@ try:
 except (ImportError, ModuleNotFoundError):
 
     def colorwheel(pos):
-        # ref: https://github.com/adafruit/circuitpython/blob/main/shared-module/rainbowio/__init__.c
+        """
+        Generate a color from a position value on a color wheel.
+        This function maps an input position (0-255) to a color on a
+        virtual RGB color wheel. The colors transition smoothly through
+        red, green, and blue.
+        :param float pos: Position on the color wheel (0-255). Values outside
+                        this range will be wrapped around.
+        :return: color
+        """
+
+        # ref:
+        # https://github.com/adafruit/circuitpython/blob/main/shared-module/rainbowio/__init__.c
         pos = pos - ((pos // 256) * 256)
         shift1 = 0
         shift2 = 0
@@ -44,9 +55,9 @@ except (ImportError, ModuleNotFoundError):
             pos -= 170
             shift1 = 16
             shift2 = 0
-        p = (int)(pos * 3)
-        p = p if (p < 256) else 255
-        return (p << shift1) | ((255 - p) << shift2)
+        pos_new = (int)(pos * 3)
+        pos_new = pos_new if (pos_new < 256) else 255
+        return (pos_new << shift1) | ((255 - pos_new) << shift2)
 
 
 RED = (255, 0, 0)

--- a/adafruit_led_animation/color.py
+++ b/adafruit_led_animation/color.py
@@ -24,7 +24,28 @@ Implementation Notes
   https://circuitpython.org/downloads
 """
 # Makes colorwheel() available.
-from rainbowio import colorwheel  # pylint: disable=unused-import
+try:
+    from rainbowio import colorwheel  # pylint: disable=unused-import
+except (ImportError, ModuleNotFoundError):
+    def colorwheel(pos):
+        # ref: https://github.com/adafruit/circuitpython/blob/main/shared-module/rainbowio/__init__.c
+        pos = pos - ((pos // 256) * 256)
+        shift1 = 0
+        shift2 = 0
+        if (pos < 85):
+            shift1 = 8
+            shift2 = 16
+        elif (pos < 170):
+            pos -= 85
+            shift1 = 0
+            shift2 = 8
+        else:
+            pos -= 170
+            shift1 = 16
+            shift2 = 0
+        p = (int)(pos * 3)
+        p = p if (p < 256) else 255
+        return (p << shift1) | ((255 - p) << shift2)
 
 RED = (255, 0, 0)
 """Red."""

--- a/adafruit_led_animation/color.py
+++ b/adafruit_led_animation/color.py
@@ -27,15 +27,16 @@ Implementation Notes
 try:
     from rainbowio import colorwheel  # pylint: disable=unused-import
 except (ImportError, ModuleNotFoundError):
+
     def colorwheel(pos):
         # ref: https://github.com/adafruit/circuitpython/blob/main/shared-module/rainbowio/__init__.c
         pos = pos - ((pos // 256) * 256)
         shift1 = 0
         shift2 = 0
-        if (pos < 85):
+        if pos < 85:
             shift1 = 8
             shift2 = 16
-        elif (pos < 170):
+        elif pos < 170:
             pos -= 85
             shift1 = 0
             shift2 = 8
@@ -46,6 +47,7 @@ except (ImportError, ModuleNotFoundError):
         p = (int)(pos * 3)
         p = p if (p < 256) else 255
         return (p << shift1) | ((255 - p) << shift2)
+
 
 RED = (255, 0, 0)
 """Red."""

--- a/adafruit_led_animation/grid.py
+++ b/adafruit_led_animation/grid.py
@@ -34,7 +34,7 @@ from .helper import (
     pixel_object_auto_write,
     pixel_object_auto_write_set,
     pixel_object_brightness,
-    pixel_object_brightness_set
+    pixel_object_brightness_set,
 )
 
 

--- a/adafruit_led_animation/grid.py
+++ b/adafruit_led_animation/grid.py
@@ -130,7 +130,7 @@ class PixelGrid:
         else:
             raise ValueError("PixelGrid assignment needs a sub-index or x,y coordinate")
 
-        if self._pixels.auto_write:
+        if hasattr(self._pixels, "auto_write") and self._pixels.auto_write:
             self.show()
 
     def __getitem__(self, index):
@@ -150,12 +150,13 @@ class PixelGrid:
         """
         brightness from the underlying strip.
         """
-        return self._pixels.brightness
+        return self._pixels.brightness if hasattr(self._pixels, "brightness") else 1.0
 
     @brightness.setter
     def brightness(self, brightness):
-        # pylint: disable=attribute-defined-outside-init
-        self._pixels.brightness = min(max(brightness, 0.0), 1.0)
+        if hasattr(self._pixels, "brightness"):
+            # pylint: disable=attribute-defined-outside-init
+            self._pixels.brightness = min(max(brightness, 0.0), 1.0)
 
     def fill(self, color):
         """
@@ -170,18 +171,22 @@ class PixelGrid:
         """
         Shows the pixels on the underlying strip.
         """
-        self._pixels.show()
+        if hasattr(self._pixels, "show"):
+            self._pixels.show()
+        elif hasattr(self._pixels, "write"):
+            self._pixels.write()
 
     @property
     def auto_write(self):
         """
         auto_write from the underlying strip.
         """
-        return self._pixels.auto_write
+        return hasattr(self._pixels, "auto_write") and self._pixels.auto_write
 
     @auto_write.setter
     def auto_write(self, value):
-        self._pixels.auto_write = value
+        if hasattr(self._pixels, "auto_write"):
+            self._pixels.auto_write = value
 
 
 def reverse_x_mapper(width, mapper):

--- a/adafruit_led_animation/grid.py
+++ b/adafruit_led_animation/grid.py
@@ -27,9 +27,14 @@ Implementation Notes
 from micropython import const
 
 from .helper import (
-    PixelMap, horizontal_strip_gridmap, vertical_strip_gridmap, 
-    pixel_object_show, pixel_object_auto_write, pixel_object_auto_write_set,
-    pixel_object_brightness, pixel_object_brightness_set
+    PixelMap,
+    horizontal_strip_gridmap,
+    vertical_strip_gridmap,
+    pixel_object_show,
+    pixel_object_auto_write,
+    pixel_object_auto_write_set,
+    pixel_object_brightness,
+    pixel_object_brightness_set
 )
 
 

--- a/adafruit_led_animation/grid.py
+++ b/adafruit_led_animation/grid.py
@@ -26,7 +26,11 @@ Implementation Notes
 """
 from micropython import const
 
-from .helper import PixelMap, horizontal_strip_gridmap, vertical_strip_gridmap
+from .helper import (
+    PixelMap, horizontal_strip_gridmap, vertical_strip_gridmap, 
+    pixel_object_show, pixel_object_auto_write, pixel_object_auto_write_set,
+    pixel_object_brightness, pixel_object_brightness_set
+)
 
 
 HORIZONTAL = const(1)
@@ -130,7 +134,7 @@ class PixelGrid:
         else:
             raise ValueError("PixelGrid assignment needs a sub-index or x,y coordinate")
 
-        if hasattr(self._pixels, "auto_write") and self._pixels.auto_write:
+        if pixel_object_auto_write(self._pixels):
             self.show()
 
     def __getitem__(self, index):
@@ -150,13 +154,12 @@ class PixelGrid:
         """
         brightness from the underlying strip.
         """
-        return self._pixels.brightness if hasattr(self._pixels, "brightness") else 1.0
+        return pixel_object_brightness(self._pixels)
 
     @brightness.setter
     def brightness(self, brightness):
-        if hasattr(self._pixels, "brightness"):
-            # pylint: disable=attribute-defined-outside-init
-            self._pixels.brightness = min(max(brightness, 0.0), 1.0)
+        # pylint: disable=attribute-defined-outside-init
+        pixel_object_brightness_set(self._pixels, brightness)
 
     def fill(self, color):
         """
@@ -171,22 +174,19 @@ class PixelGrid:
         """
         Shows the pixels on the underlying strip.
         """
-        if hasattr(self._pixels, "show"):
-            self._pixels.show()
-        elif hasattr(self._pixels, "write"):
-            self._pixels.write()
+        pixel_object_show(self._pixels)
 
     @property
     def auto_write(self):
         """
         auto_write from the underlying strip.
         """
-        return hasattr(self._pixels, "auto_write") and self._pixels.auto_write
+        return pixel_object_auto_write(self._pixels)
 
     @auto_write.setter
     def auto_write(self, value):
-        if hasattr(self._pixels, "auto_write"):
-            self._pixels.auto_write = value
+        # pylint: disable=attribute-defined-outside-init
+        pixel_object_auto_write_set(self._pixels, value)
 
 
 def reverse_x_mapper(width, mapper):

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -146,7 +146,10 @@ class AnimationGroup:
                 for member in self._members:
                     if isinstance(member, Animation):
                         if last_strip != member.pixel_object:
-                            member.pixel_object.show()
+                            if hasattr(member.pixel_object, "show"):
+                                member.pixel_object.show()
+                            elif hasattr(member.pixel_object, "write"):
+                                member.pixel_object.write()
                             last_strip = member.pixel_object
                     else:
                         member.show()

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -146,10 +146,7 @@ class AnimationGroup:
                 for member in self._members:
                     if isinstance(member, Animation):
                         if last_strip != member.pixel_object:
-                            if hasattr(member.pixel_object, "show"):
-                                member.pixel_object.show()
-                            elif hasattr(member.pixel_object, "write"):
-                                member.pixel_object.write()
+                            self._pixel_object_show(member.pixel_object)
                             last_strip = member.pixel_object
                     else:
                         member.show()
@@ -160,6 +157,17 @@ class AnimationGroup:
             if item.animate(show):
                 ret = True
         return ret
+
+    def _pixel_object_show(self, pixel_object):
+        """
+        Show the pixel object.  This is a helper function to handle both
+        MicroPython and CircuitPython.
+        :param pixel_object: The pixel object to show/write to.
+        """
+        if hasattr(pixel_object, "show"):
+            pixel_object.show()
+        elif hasattr(pixel_object, "write"):
+            pixel_object.write()
 
     @property
     def color(self):

--- a/adafruit_led_animation/group.py
+++ b/adafruit_led_animation/group.py
@@ -30,6 +30,7 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LED_Animation.git"
 
 from adafruit_led_animation.animation import Animation
+from adafruit_led_animation.helper import pixel_object_show
 
 
 class AnimationGroup:
@@ -146,7 +147,7 @@ class AnimationGroup:
                 for member in self._members:
                     if isinstance(member, Animation):
                         if last_strip != member.pixel_object:
-                            self._pixel_object_show(member.pixel_object)
+                            pixel_object_show(member.pixel_object)
                             last_strip = member.pixel_object
                     else:
                         member.show()
@@ -157,17 +158,6 @@ class AnimationGroup:
             if item.animate(show):
                 ret = True
         return ret
-
-    def _pixel_object_show(self, pixel_object):
-        """
-        Show the pixel object.  This is a helper function to handle both
-        MicroPython and CircuitPython.
-        :param pixel_object: The pixel object to show/write to.
-        """
-        if hasattr(pixel_object, "show"):
-            pixel_object.show()
-        elif hasattr(pixel_object, "write"):
-            pixel_object.write()
 
     @property
     def color(self):

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -138,7 +138,7 @@ class PixelMap:
         else:
             self._set_pixels(index, val)
 
-        if self._pixels.auto_write:
+        if hasattr(self._pixels, "auto_write") and self._pixels.auto_write:
             self.show()
 
     def __getitem__(self, index):
@@ -161,12 +161,13 @@ class PixelMap:
         """
         brightness from the underlying strip.
         """
-        return self._pixels.brightness
+        return self._pixels.brightness if hasattr(self._pixels, "brightness") else 1.0
 
     @brightness.setter
     def brightness(self, brightness):
-        # pylint: disable=attribute-defined-outside-init
-        self._pixels.brightness = min(max(brightness, 0.0), 1.0)
+        if hasattr(self._pixels, "brightness"):
+            # pylint: disable=attribute-defined-outside-init
+            self._pixels.brightness = min(max(brightness, 0.0), 1.0)
 
     def fill(self, color):
         """
@@ -182,18 +183,22 @@ class PixelMap:
         """
         Shows the pixels on the underlying strip.
         """
-        self._pixels.show()
+        if hasattr(self._pixels, "show"):
+            self._pixels.show()
+        elif hasattr(self._pixels, "write"):
+            self._pixels.write()
 
     @property
     def auto_write(self):
         """
         auto_write from the underlying strip.
         """
-        return self._pixels.auto_write
+        return hasattr(self._pixels, "auto_write") and self._pixels.auto_write
 
     @auto_write.setter
     def auto_write(self, value):
-        self._pixels.auto_write = value
+        if hasattr(self._pixels, "auto_write"):
+            self._pixels.auto_write = value
 
     @classmethod
     def vertical_lines(cls, pixel_object, width, height, gridmap):

--- a/adafruit_led_animation/helper.py
+++ b/adafruit_led_animation/helper.py
@@ -138,7 +138,7 @@ class PixelMap:
         else:
             self._set_pixels(index, val)
 
-        if hasattr(self._pixels, "auto_write") and self._pixels.auto_write:
+        if pixel_object_auto_write(self._pixels):
             self.show()
 
     def __getitem__(self, index):
@@ -161,13 +161,12 @@ class PixelMap:
         """
         brightness from the underlying strip.
         """
-        return self._pixels.brightness if hasattr(self._pixels, "brightness") else 1.0
+        return pixel_object_brightness(self._pixels)
 
     @brightness.setter
     def brightness(self, brightness):
-        if hasattr(self._pixels, "brightness"):
-            # pylint: disable=attribute-defined-outside-init
-            self._pixels.brightness = min(max(brightness, 0.0), 1.0)
+        # pylint: disable=attribute-defined-outside-init
+        pixel_object_brightness_set(self._pixels, brightness)
 
     def fill(self, color):
         """
@@ -183,22 +182,19 @@ class PixelMap:
         """
         Shows the pixels on the underlying strip.
         """
-        if hasattr(self._pixels, "show"):
-            self._pixels.show()
-        elif hasattr(self._pixels, "write"):
-            self._pixels.write()
+        pixel_object_show(self._pixels)
 
     @property
     def auto_write(self):
         """
         auto_write from the underlying strip.
         """
-        return hasattr(self._pixels, "auto_write") and self._pixels.auto_write
+        return pixel_object_auto_write(self._pixels)
 
     @auto_write.setter
     def auto_write(self, value):
-        if hasattr(self._pixels, "auto_write"):
-            self._pixels.auto_write = value
+        # pylint: disable=attribute-defined-outside-init
+        pixel_object_auto_write_set(self._pixels, value)
 
     @classmethod
     def vertical_lines(cls, pixel_object, width, height, gridmap):
@@ -315,3 +311,57 @@ class PixelSubset(PixelMap):
             pixel_ranges=[[n] for n in range(start, end)],
             individual_pixels=True,
         )
+
+
+def pixel_object_show(pixel_object):
+    """
+    Show the pixel object.  This is a helper function to handle both
+    MicroPython and CircuitPython.
+    :param pixel_object: The pixel object to show/write to.
+    """
+    if hasattr(pixel_object, "show"):
+        pixel_object.show()
+    elif hasattr(pixel_object, "write"):
+        pixel_object.write()
+
+
+def pixel_object_auto_write(pixel_object):
+    """
+    Get the auto_write property of the pixel object.
+    :param pixel_object: The pixel object to get the auto_write property from.
+    :return: The auto_write property of the pixel object.
+    """
+    if hasattr(pixel_object, "auto_write"):
+        return pixel_object.auto_write
+    return False
+
+
+def pixel_object_auto_write_set(pixel_object, value):
+    """
+    Set the auto_write property of the pixel object.
+    :param pixel_object: The pixel object to set the auto_write property on.
+    :param value: The value to set the auto_write property to.
+    """
+    if hasattr(pixel_object, "auto_write"):
+        pixel_object.auto_write = value
+
+
+def pixel_object_brightness(pixel_object):
+    """
+    Get the brightness property of the pixel object.
+    :param pixel_object: The pixel object to get the brightness property from.
+    :return: The brightness property of the pixel object.
+    """
+    if hasattr(pixel_object, "brightness"):
+        return pixel_object.brightness
+    return 1.0
+
+
+def pixel_object_brightness_set(pixel_object, value):
+    """
+    Set the brightness property of the pixel object.
+    :param pixel_object: The pixel object to set the brightness property on.
+    :param value: The value to set the brightness property to.
+    """
+    if hasattr(pixel_object, "brightness"):
+        pixel_object.brightness = value


### PR DESCRIPTION
MicroPython has a `neopixel` library, but it's functionality is not as robust as CircuitPythons:
https://docs.micropython.org/en/latest/library/neopixel.html

In our situation, we had a project which required an OpenMV board, which runs MicroPython instead of CircuitPython. In this case, OpenMV has their own fork of MicroPython, which has a similar `neopixel` library:
https://docs.openmv.io/library/neopixel.html

This PR allows the `Adafruit_CircuitPython_LED_Animation` to work with the `neopixel` library from OpenMV's fork of MicroPython. 

However, given "CircuitPython" is in the name of this library, I'm uncertain if it makes sense to merge this PR .. or create a dedicated fork for OpenMV MicroPython?