### PR TITLE
Fix initial offset calculation when reversed in chase.py

### DIFF
--- a/adafruit_led_animation/animation/chase.py
+++ b/adafruit_led_animation/animation/chase.py
@@ -51,10 +51,10 @@ class Chase(Animation):
         self._overflow = len(pixel_object) % self._repeat_width
         self._direction = 1 if not reverse else -1
         self._reverse = reverse
-        self._offset = 0
+        self._offset = 0 if not reverse else len(pixel_object) - size
 
         def _resetter():
-            self._offset = 0
+            self._offset = 0 if not reverse else len(self.pixel_object) - size
             self._reverse = reverse
             self._direction = 1 if not reverse else -1
 


### PR DESCRIPTION
Found a bug in the chase animation when reverse is set to True which results in the animation being offset by the length of the size parameter.  You can observe this by setting up two animations of equal length on a single strip of pixels with the second one reversed.  The bars should appear to meet in the middle but don't.  We could consider removing _num_repeats and _overflow as they don't appear to be used (at least, searching this repo didn't turn up any hits)

Example:
```py
pixels = neopixel.NeoPixel(board.A0, 22, auto_write=False, brightness = .5) left_pixels = PixelSubset(pixels, 0, 11)
right_pixels = PixelSubset(pixels, 11, 22)
left_animation = Chase(
    left_pixels, speed=.5, color=CYAN, size=2, spacing=11
)

right_animation = Chase(
    right_pixels, speed=.5, color=CYAN, size=2, spacing=11, reverse=True
)

animations = AnimationSequence(
    AnimationGroup(
        left_animation,
        right_animation,
        sync=True
    ),
    auto_clear=True,
    auto_reset=True,
)

while True:
    animations.animate()
```